### PR TITLE
feat: implement orders section and routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,6 +11,13 @@ export const routes: Routes = [
   { path: '', redirectTo: 'sign-in', pathMatch: 'full' },
   { path: 'sign-in', loadComponent: SignInComponent, data: { title: `${baseTitle} | Sign In` } },
   { path: 'sign-up', loadComponent: SignUpComponent, data: { title: `${baseTitle} | Sign Up` } },
-  { path: 'dashboard',loadComponent: DashboardComponent,children: [{ path: '', redirectTo: 'home', pathMatch: 'full' },]},
+  {
+    path: 'dashboard',
+    loadComponent: DashboardComponent,
+    children: [
+      { path: '', redirectTo: 'sales', pathMatch: 'full' },
+      { path: 'sales', loadChildren: () => import('./orders/orders.routes').then(m => m.ORDERS_ROUTES) }
+    ]
+  },
   { path: '**', loadComponent: PageNotFoundComponent, data: { title: `${baseTitle} | Page Not Found` } }
 ];

--- a/src/app/orders/components/order-list/order-list.component.css
+++ b/src/app/orders/components/order-list/order-list.component.css
@@ -1,0 +1,158 @@
+.order-list {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 16px 32px rgba(108, 55, 140, 0.12);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.order-list__header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.order-list__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2b0a3d;
+}
+
+.order-list__filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  background: #ede7f6;
+  color: #5b2a86;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.filter-chip--active {
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+}
+
+.order-list__table-wrapper {
+  overflow-x: auto;
+}
+
+.order-list__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.order-list__table thead {
+  background: #f5f0ff;
+}
+
+.order-list__table th,
+.order-list__table td {
+  text-align: left;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid #ede7f6;
+}
+
+.order-list__table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.order-list__table tbody tr:hover {
+  background: rgba(142, 36, 170, 0.08);
+}
+
+.order-code {
+  font-weight: 700;
+  color: #4a148c;
+}
+
+.order-customer {
+  display: block;
+  font-weight: 600;
+}
+
+.order-customer__email {
+  color: #7e57c2;
+}
+
+.order-list__actions button {
+  border: none;
+  background: transparent;
+  color: #6a1b9a;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  transition: background 0.2s ease;
+}
+
+.order-list__actions button:hover {
+  background: rgba(106, 27, 154, 0.1);
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge--pending {
+  background: rgba(255, 193, 7, 0.18);
+  color: #ff8f00;
+}
+
+.badge--processing {
+  background: rgba(33, 150, 243, 0.18);
+  color: #1976d2;
+}
+
+.badge--completed {
+  background: rgba(76, 175, 80, 0.18);
+  color: #2e7d32;
+}
+
+.badge--cancelled {
+  background: rgba(244, 67, 54, 0.18);
+  color: #c62828;
+}
+
+.order-list__empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #5b2a86;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-list__empty a {
+  align-self: center;
+  text-decoration: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .order-list {
+    padding: 1.25rem;
+  }
+}

--- a/src/app/orders/components/order-list/order-list.component.html
+++ b/src/app/orders/components/order-list/order-list.component.html
@@ -1,1 +1,58 @@
-<p>order-list works!</p>
+<section class="order-list">
+  <header class="order-list__header">
+    <h2>Pedidos recientes</h2>
+    <nav class="order-list__filters">
+      <button
+        type="button"
+        class="filter-chip"
+        *ngFor="let filter of statusFilters"
+        (click)="setFilter(filter.value)"
+        [class.filter-chip--active]="(statusFilter$ | async) === filter.value"
+      >
+        {{ filter.label }}
+      </button>
+    </nav>
+  </header>
+
+  <div class="order-list__table-wrapper" *ngIf="filteredOrders$ | async as orders">
+    <table class="order-list__table" *ngIf="orders.length; else emptyState">
+      <thead>
+        <tr>
+          <th>Código</th>
+          <th>Cliente</th>
+          <th>Fecha</th>
+          <th>Estado</th>
+          <th>Total</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let order of orders; trackBy: trackByOrderId">
+          <td>
+            <span class="order-code">{{ order.code }}</span>
+          </td>
+          <td>
+            <span class="order-customer">{{ order.customerName }}</span>
+            <small class="order-customer__email" *ngIf="order.customerEmail">{{ order.customerEmail }}</small>
+          </td>
+          <td>{{ order.createdAt | date:'mediumDate' }}</td>
+          <td>
+            <span class="badge" [class]="statusBadges[order.status]">{{ filterLabels[order.status] }}</span>
+          </td>
+          <td>{{ order.total | currency:'USD':'symbol':'1.0-0' }}</td>
+          <td class="order-list__actions">
+            <button type="button" (click)="goToOrderDetail(order)">Ver detalle</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<ng-template #emptyState>
+  <div class="order-list__empty">
+    <h3>No hay pedidos registrados</h3>
+    <p>Comienza creando tu primer pedido para visualizarlo en esta lista.</p>
+    <a routerLink="/dashboard/sales/new">Crear pedido</a>
+  </div>
+</ng-template>

--- a/src/app/orders/components/order-list/order-list.component.ts
+++ b/src/app/orders/components/order-list/order-list.component.ts
@@ -1,11 +1,74 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule, DatePipe, CurrencyPipe } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { BehaviorSubject, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { OrdersService } from '../../services/orders.service';
+import { Order, OrderStatus } from '../../models/order.entity';
+
+interface StatusFilter {
+  value: OrderStatus | 'all';
+  label: string;
+}
 
 @Component({
   selector: 'app-order-list',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe, CurrencyPipe],
   templateUrl: './order-list.component.html',
-  styleUrl: './order-list.component.css'
+  styleUrls: ['./order-list.component.css']
 })
 export class OrderListComponent {
+  private readonly ordersService = inject(OrdersService);
+  private readonly router = inject(Router);
 
+  private readonly statusFilterSubject = new BehaviorSubject<OrderStatus | 'all'>('all');
+
+  readonly statusFilter$ = this.statusFilterSubject.asObservable();
+  readonly orders$ = this.ordersService.getOrders();
+
+  readonly filteredOrders$ = combineLatest([this.orders$, this.statusFilter$]).pipe(
+    map(([orders, filter]) => {
+      if (filter === 'all') {
+        return orders;
+      }
+
+      return orders.filter(order => order.status === filter);
+    })
+  );
+
+  readonly statusFilters: StatusFilter[] = [
+    { value: 'all', label: 'Todos' },
+    { value: 'pending', label: 'Pendientes' },
+    { value: 'processing', label: 'En preparación' },
+    { value: 'completed', label: 'Completados' },
+    { value: 'cancelled', label: 'Cancelados' }
+  ];
+
+  readonly statusBadges: Record<OrderStatus, string> = {
+    pending: 'badge--pending',
+    processing: 'badge--processing',
+    completed: 'badge--completed',
+    cancelled: 'badge--cancelled'
+  };
+
+  readonly filterLabels: Record<OrderStatus, string> = {
+    pending: 'Pendiente',
+    processing: 'En preparación',
+    completed: 'Completado',
+    cancelled: 'Cancelado'
+  };
+
+  setFilter(filter: StatusFilter['value']): void {
+    this.statusFilterSubject.next(filter);
+  }
+
+  trackByOrderId(_: number, order: Order): string {
+    return order.id;
+  }
+
+  goToOrderDetail(order: Order): void {
+    this.router.navigate(['/dashboard', 'sales', order.id]);
+  }
 }

--- a/src/app/orders/models/catalog-item.entity.ts
+++ b/src/app/orders/models/catalog-item.entity.ts
@@ -1,0 +1,63 @@
+export interface CatalogItem {
+  id: string;
+  name: string;
+  varietal: string;
+  vintage: number;
+  origin: string;
+  price: number;
+  imageUrl?: string;
+  tastingNotes?: string;
+}
+
+export const MOCK_CATALOG_ITEMS: CatalogItem[] = [
+  {
+    id: 'cab-2018',
+    name: 'Gran Reserva Cabernet Sauvignon',
+    varietal: 'Cabernet Sauvignon',
+    vintage: 2018,
+    origin: 'Napa Valley, USA',
+    price: 58,
+    imageUrl: 'https://images.unsplash.com/photo-1543248939-ff40856f65d4',
+    tastingNotes: 'Notas de cassis, vainilla y roble tostado con taninos redondos.'
+  },
+  {
+    id: 'mal-2019',
+    name: 'Alturas Andinas Malbec',
+    varietal: 'Malbec',
+    vintage: 2019,
+    origin: 'Mendoza, Argentina',
+    price: 42,
+    imageUrl: 'https://images.unsplash.com/photo-1543248986-42142f9b6043',
+    tastingNotes: 'Frutos rojos maduros, especias dulces y final persistente.'
+  },
+  {
+    id: 'cha-2020',
+    name: 'Costa Dorada Chardonnay',
+    varietal: 'Chardonnay',
+    vintage: 2020,
+    origin: 'Casablanca, Chile',
+    price: 36,
+    imageUrl: 'https://images.unsplash.com/photo-1514533450685-26ef7784906e',
+    tastingNotes: 'Aromas cítricos, mantequilla fresca y delicado tostado.'
+  },
+  {
+    id: 'tem-2017',
+    name: 'Viña Antigua Tempranillo',
+    varietal: 'Tempranillo',
+    vintage: 2017,
+    origin: 'Rioja, España',
+    price: 49,
+    imageUrl: 'https://images.unsplash.com/photo-1527169402691-feff5539e52c',
+    tastingNotes: 'Ciruelas maduras, tabaco y notas de cuero envejecido.'
+  },
+  {
+    id: 'ros-2022',
+    name: 'Rosé Mediterráneo',
+    varietal: 'Grenache',
+    vintage: 2022,
+    origin: 'Provenza, Francia',
+    price: 24,
+    imageUrl: 'https://images.unsplash.com/photo-1527169402991-3546847d86be',
+    tastingNotes: 'Refrescante, floral y con un delicado toque mineral.'
+  }
+];

--- a/src/app/orders/models/order.entity.ts
+++ b/src/app/orders/models/order.entity.ts
@@ -1,0 +1,38 @@
+import { CatalogItem } from './catalog-item.entity';
+
+export type OrderStatus = 'pending' | 'processing' | 'completed' | 'cancelled';
+
+export interface OrderItem {
+  id: string;
+  catalogItem: CatalogItem;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+}
+
+export interface Order {
+  id: string;
+  code: string;
+  customerName: string;
+  customerEmail?: string;
+  status: OrderStatus;
+  createdAt: string;
+  expectedDelivery?: string;
+  notes?: string;
+  items: OrderItem[];
+  subtotal: number;
+  tax: number;
+  total: number;
+}
+
+export interface NewOrderItemInput {
+  catalogItemId: string;
+  quantity: number;
+}
+
+export interface NewOrderInput {
+  customerName: string;
+  customerEmail?: string;
+  notes?: string;
+  items: NewOrderItemInput[];
+}

--- a/src/app/orders/orders.routes.ts
+++ b/src/app/orders/orders.routes.ts
@@ -1,0 +1,23 @@
+import { Routes } from '@angular/router';
+
+const OrdersPage = () => import('./pages/orders/orders.component').then(m => m.OrdersComponent);
+const NewOrderPage = () => import('./pages/new-order/new-order.component').then(m => m.NewOrderComponent);
+const OrderDetailPage = () => import('./pages/order-detail/order-detail.component').then(m => m.OrderDetailComponent);
+
+export const ORDERS_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: OrdersPage,
+    data: { title: 'WineInventory | Pedidos' }
+  },
+  {
+    path: 'new',
+    loadComponent: NewOrderPage,
+    data: { title: 'WineInventory | Nuevo pedido' }
+  },
+  {
+    path: ':orderId',
+    loadComponent: OrderDetailPage,
+    data: { title: 'WineInventory | Detalle del pedido' }
+  }
+];

--- a/src/app/orders/pages/new-order/new-order.component.css
+++ b/src/app/orders/pages/new-order/new-order.component.css
@@ -1,0 +1,207 @@
+.new-order {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.new-order__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.new-order__header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #2b0a3d;
+}
+
+.new-order__header p {
+  margin: 0.5rem 0 0;
+  max-width: 520px;
+  color: #5a5a5a;
+}
+
+.new-order__header a {
+  text-decoration: none;
+  color: #6a1b9a;
+  font-weight: 600;
+}
+
+.new-order__form {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 18px 36px rgba(108, 55, 140, 0.14);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-section h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #4a148c;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-header button {
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field span {
+  font-weight: 600;
+  color: #5b2a86;
+}
+
+.form-field input,
+.form-field textarea,
+.order-item select,
+.order-item input {
+  border-radius: 0.75rem;
+  border: 1px solid #d1c4e9;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.order-item select:focus,
+.order-item input:focus {
+  outline: none;
+  border-color: #7e57c2;
+  box-shadow: 0 0 0 3px rgba(126, 87, 194, 0.15);
+}
+
+.form-field--full {
+  grid-column: 1 / -1;
+}
+
+.error {
+  color: #c62828;
+  font-size: 0.8rem;
+}
+
+.order-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-item {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #f7f1ff;
+}
+
+.order-item label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.order-item .remove {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: #c62828;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.preview-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.preview-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.preview-totals {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.preview-totals div {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.preview-totals__total {
+  font-size: 1.2rem;
+  color: #4a148c;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-actions button {
+  border: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(106, 27, 154, 0.24);
+}
+
+@media (max-width: 768px) {
+  .new-order {
+    padding: 1.5rem;
+  }
+
+  .new-order__form {
+    padding: 1.5rem;
+  }
+}

--- a/src/app/orders/pages/new-order/new-order.component.html
+++ b/src/app/orders/pages/new-order/new-order.component.html
@@ -1,1 +1,99 @@
-<p>new-order works!</p>
+<section class="new-order">
+  <header class="new-order__header">
+    <div>
+      <h1>Nuevo pedido</h1>
+      <p>Completa la información del cliente y selecciona los vinos que formarán parte del pedido.</p>
+    </div>
+    <nav>
+      <a routerLink="/dashboard/sales">Volver al listado</a>
+    </nav>
+  </header>
+
+  <form [formGroup]="orderForm" (ngSubmit)="submit()" class="new-order__form">
+    <section class="form-section">
+      <h2>Datos del cliente</h2>
+      <div class="form-grid">
+        <label class="form-field">
+          <span>Nombre del cliente *</span>
+          <input type="text" formControlName="customerName" placeholder="Ej. Restaurante La Vid" />
+          <small class="error" *ngIf="orderForm.get('customerName')?.touched && orderForm.get('customerName')?.hasError('required')">
+            Este campo es obligatorio.
+          </small>
+        </label>
+        <label class="form-field">
+          <span>Correo electrónico</span>
+          <input type="email" formControlName="customerEmail" placeholder="correo@cliente.com" />
+          <small class="error" *ngIf="orderForm.get('customerEmail')?.touched && orderForm.get('customerEmail')?.hasError('email')">
+            Ingresa un correo válido.
+          </small>
+        </label>
+        <label class="form-field form-field--full">
+          <span>Notas adicionales</span>
+          <textarea rows="3" formControlName="notes" placeholder="Indica instrucciones especiales de entrega"></textarea>
+        </label>
+      </div>
+    </section>
+
+    <section class="form-section">
+      <div class="section-header">
+        <h2>Detalle del pedido</h2>
+        <button type="button" (click)="addItem()">Agregar producto</button>
+      </div>
+
+      <div class="order-items" formArrayName="items">
+        <div class="order-item" *ngFor="let item of items.controls; let i = index; trackBy: trackByIndex" [formGroupName]="i">
+          <label>
+            <span>Producto *</span>
+            <select formControlName="catalogItemId">
+              <option [ngValue]="null" disabled>Selecciona una referencia</option>
+              <option *ngFor="let catalogItem of (catalogItems$ | async)" [ngValue]="catalogItem.id">
+                {{ catalogItem.name }} · {{ catalogItem.vintage }} · {{ catalogItem.price | currency:'USD':'symbol':'1.0-0' }}
+              </option>
+            </select>
+            <small class="error" *ngIf="item.get('catalogItemId')?.touched && item.get('catalogItemId')?.hasError('required')">
+              Selecciona un producto.
+            </small>
+          </label>
+
+          <label>
+            <span>Cantidad *</span>
+            <input type="number" min="1" formControlName="quantity" />
+            <small class="error" *ngIf="item.get('quantity')?.touched && item.get('quantity')?.hasError('min')">
+              Debe ser al menos 1 unidad.
+            </small>
+          </label>
+
+          <button type="button" class="remove" (click)="removeItem(i)" *ngIf="items.length > 1">Eliminar</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="form-section" *ngIf="orderPreview$ | async as preview">
+      <h2>Resumen</h2>
+      <ul class="preview-list">
+        <li *ngFor="let item of preview.items">
+          <span>{{ item.name }} · {{ item.quantity }} uds.</span>
+          <strong>{{ item.total | currency:'USD':'symbol':'1.0-0' }}</strong>
+        </li>
+      </ul>
+      <div class="preview-totals">
+        <div>
+          <span>Subtotal</span>
+          <strong>{{ preview.subtotal | currency:'USD':'symbol':'1.0-0' }}</strong>
+        </div>
+        <div>
+          <span>Impuestos (19%)</span>
+          <strong>{{ preview.tax | currency:'USD':'symbol':'1.0-0' }}</strong>
+        </div>
+        <div class="preview-totals__total">
+          <span>Total</span>
+          <strong>{{ preview.total | currency:'USD':'symbol':'1.0-0' }}</strong>
+        </div>
+      </div>
+    </section>
+
+    <footer class="form-actions">
+      <button type="submit">Guardar pedido</button>
+    </footer>
+  </form>
+</section>

--- a/src/app/orders/pages/new-order/new-order.component.ts
+++ b/src/app/orders/pages/new-order/new-order.component.ts
@@ -1,11 +1,127 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule, CurrencyPipe } from '@angular/common';
+import { Router } from '@angular/router';
+import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { combineLatest } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
+
+import { CatalogService } from '../../services/catalog.service';
+import { OrdersService } from '../../services/orders.service';
+import { CatalogItem } from '../../models/catalog-item.entity';
+import { NewOrderInput } from '../../models/order.entity';
+
+interface OrderFormItemValue {
+  catalogItemId: string | null;
+  quantity: number | null;
+}
+
+interface OrderFormValue {
+  customerName: string | null;
+  customerEmail: string | null;
+  notes: string | null;
+  items: OrderFormItemValue[] | null;
+}
 
 @Component({
   selector: 'app-new-order',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, CurrencyPipe],
   templateUrl: './new-order.component.html',
-  styleUrl: './new-order.component.css'
+  styleUrls: ['./new-order.component.css']
 })
-export class NewOrderComponent {
+export class NewOrderComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly catalogService = inject(CatalogService);
+  private readonly ordersService = inject(OrdersService);
+  private readonly router = inject(Router);
 
+  readonly catalogItems$ = this.catalogService.getCatalog();
+
+  readonly orderForm: FormGroup = this.fb.group({
+    customerName: ['', Validators.required],
+    customerEmail: ['', Validators.email],
+    notes: [''],
+    items: this.fb.array([])
+  });
+
+  readonly orderPreview$ = combineLatest([
+    this.catalogItems$,
+    this.orderForm.valueChanges.pipe(startWith(this.orderForm.value))
+  ]).pipe(
+    map(([catalog, formValue]) => this.buildPreview(catalog, formValue as OrderFormValue))
+  );
+
+  ngOnInit(): void {
+    this.addItem();
+  }
+
+  get items(): FormArray {
+    return this.orderForm.get('items') as FormArray;
+  }
+
+  addItem(): void {
+    this.items.push(
+      this.fb.group({
+        catalogItemId: [null, Validators.required],
+        quantity: [1, [Validators.required, Validators.min(1)]]
+      })
+    );
+  }
+
+  removeItem(index: number): void {
+    this.items.removeAt(index);
+  }
+
+  submit(): void {
+    if (this.orderForm.invalid) {
+      this.orderForm.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.orderForm.value as OrderFormValue;
+    const rawItems = (formValue.items ?? []) as OrderFormItemValue[];
+    const payload: NewOrderInput = {
+      customerName: formValue.customerName!,
+      customerEmail: formValue.customerEmail ?? undefined,
+      notes: formValue.notes ?? undefined,
+      items: rawItems.map(item => ({
+        catalogItemId: item?.catalogItemId!,
+        quantity: Number(item?.quantity ?? 1)
+      }))
+    };
+
+    this.ordersService.createOrder(payload);
+    this.router.navigate(['/dashboard', 'sales']);
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  private buildPreview(catalog: CatalogItem[], formValue: OrderFormValue) {
+    const rawItems = (formValue.items ?? []) as OrderFormItemValue[];
+    const items = rawItems.map(item => {
+      const catalogItem = catalog.find(c => c.id === item?.catalogItemId);
+      const quantity = Number(item?.quantity ?? 0);
+      const unitPrice = catalogItem?.price ?? 0;
+      return {
+        id: item?.catalogItemId,
+        name: catalogItem?.name ?? 'Sin seleccionar',
+        quantity,
+        unitPrice,
+        total: quantity * unitPrice
+      };
+    });
+
+    const subtotal = items.reduce((acc: number, item: any) => acc + item.total, 0);
+    const tax = Math.round(subtotal * 0.19 * 100) / 100;
+    const total = Math.round((subtotal + tax) * 100) / 100;
+
+    return {
+      items,
+      subtotal,
+      tax,
+      total
+    };
+  }
 }

--- a/src/app/orders/pages/order-detail/order-detail.component.css
+++ b/src/app/orders/pages/order-detail/order-detail.component.css
@@ -1,0 +1,165 @@
+.order-detail {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.order-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail__header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #2b0a3d;
+}
+
+.order-detail__header p {
+  margin: 0.25rem 0 0;
+  color: #6a6a6a;
+}
+
+.order-detail__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.order-detail__actions select {
+  border-radius: 999px;
+  border: 1px solid #d1c4e9;
+  padding: 0.5rem 1rem;
+}
+
+.order-detail__actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.order-detail__info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.order-detail__info article {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 16px 32px rgba(108, 55, 140, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-detail__info h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #4a148c;
+}
+
+.order-detail__customer {
+  font-weight: 700;
+}
+
+.order-detail__notes {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: #f7f1ff;
+  color: #5b2a86;
+}
+
+.order-detail__items {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 18px 36px rgba(108, 55, 140, 0.14);
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+.order-detail__items h2 {
+  margin-top: 0;
+  color: #4a148c;
+}
+
+.order-detail__items table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.order-detail__items th,
+.order-detail__items td {
+  padding: 0.85rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #ede7f6;
+}
+
+.item-name {
+  display: block;
+  font-weight: 600;
+  color: #4a148c;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  background: #ede7f6;
+  color: #4a148c;
+  font-weight: 600;
+}
+
+.badge.pending {
+  background: rgba(255, 193, 7, 0.18);
+  color: #ff8f00;
+}
+
+.badge.processing {
+  background: rgba(33, 150, 243, 0.18);
+  color: #1976d2;
+}
+
+.badge.completed {
+  background: rgba(76, 175, 80, 0.18);
+  color: #2e7d32;
+}
+
+.badge.cancelled {
+  background: rgba(244, 67, 54, 0.18);
+  color: #c62828;
+}
+
+.order-detail__empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: #5b2a86;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-detail__empty a {
+  align-self: center;
+  text-decoration: none;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .order-detail {
+    padding: 1.5rem;
+  }
+}

--- a/src/app/orders/pages/order-detail/order-detail.component.html
+++ b/src/app/orders/pages/order-detail/order-detail.component.html
@@ -1,1 +1,71 @@
-<p>order-detail works!</p>
+<section class="order-detail" *ngIf="order$ | async as order; else notFound">
+  <header class="order-detail__header">
+    <div>
+      <h1>Pedido {{ order.code }}</h1>
+      <p>Creado el {{ order.createdAt | date:'medium' }}</p>
+    </div>
+    <div class="order-detail__actions">
+      <select [value]="order.status" (change)="updateStatus(order, $any($event.target).value)">
+        <option *ngFor="let status of statusOptions" [value]="status">{{ statusLabels[status] }}</option>
+      </select>
+      <button type="button" (click)="goBack()">Volver</button>
+    </div>
+  </header>
+
+  <section class="order-detail__info">
+    <article>
+      <h2>Cliente</h2>
+      <p class="order-detail__customer">{{ order.customerName }}</p>
+      <p *ngIf="order.customerEmail">{{ order.customerEmail }}</p>
+      <p *ngIf="order.notes" class="order-detail__notes">{{ order.notes }}</p>
+    </article>
+    <article>
+      <h2>Entrega</h2>
+      <p>Fecha estimada: {{ order.expectedDelivery | date:'mediumDate' }}</p>
+      <p>Estado: <span class="badge" [class]="'badge ' + (order.status | lowercase)">{{ statusLabels[order.status] }}</span></p>
+    </article>
+    <article>
+      <h2>Resumen</h2>
+      <p>Subtotal: <strong>{{ order.subtotal | currency:'USD':'symbol':'1.0-0' }}</strong></p>
+      <p>Impuestos: <strong>{{ order.tax | currency:'USD':'symbol':'1.0-0' }}</strong></p>
+      <p>Total: <strong>{{ order.total | currency:'USD':'symbol':'1.0-0' }}</strong></p>
+    </article>
+  </section>
+
+  <section class="order-detail__items">
+    <h2>Productos</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Referencia</th>
+          <th>Varietal</th>
+          <th>Cosecha</th>
+          <th>Cantidad</th>
+          <th>Precio unitario</th>
+          <th>Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of order.items">
+          <td>
+            <span class="item-name">{{ item.catalogItem.name }}</span>
+            <small>{{ item.catalogItem.origin }}</small>
+          </td>
+          <td>{{ item.catalogItem.varietal }}</td>
+          <td>{{ item.catalogItem.vintage }}</td>
+          <td>{{ item.quantity }}</td>
+          <td>{{ item.unitPrice | currency:'USD':'symbol':'1.0-0' }}</td>
+          <td>{{ item.lineTotal | currency:'USD':'symbol':'1.0-0' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</section>
+
+<ng-template #notFound>
+  <div class="order-detail__empty">
+    <h2>Pedido no encontrado</h2>
+    <p>El identificador proporcionado no coincide con ningún pedido registrado.</p>
+    <a routerLink="/dashboard/sales">Volver al listado</a>
+  </div>
+</ng-template>

--- a/src/app/orders/pages/order-detail/order-detail.component.ts
+++ b/src/app/orders/pages/order-detail/order-detail.component.ts
@@ -1,11 +1,50 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule, DatePipe, CurrencyPipe } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { map, switchMap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+
+import { OrdersService } from '../../services/orders.service';
+import { Order, OrderStatus } from '../../models/order.entity';
 
 @Component({
   selector: 'app-order-detail',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe, CurrencyPipe],
   templateUrl: './order-detail.component.html',
-  styleUrl: './order-detail.component.css'
+  styleUrls: ['./order-detail.component.css']
 })
 export class OrderDetailComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly ordersService = inject(OrdersService);
 
+  readonly order$: Observable<Order | null> = this.route.paramMap.pipe(
+    switchMap(params => {
+      const orderId = params.get('orderId') ?? params.get('id');
+      if (!orderId) {
+        return of(null);
+      }
+      return this.ordersService.getOrderById(orderId).pipe(map(order => order ?? null));
+    })
+  );
+
+  readonly statusLabels: Record<OrderStatus, string> = {
+    pending: 'Pendiente',
+    processing: 'En preparación',
+    completed: 'Completado',
+    cancelled: 'Cancelado'
+  };
+
+  readonly statusOptions: OrderStatus[] = ['pending', 'processing', 'completed', 'cancelled'];
+
+  updateStatus(order: Order, status: string): void {
+    if (this.statusOptions.includes(status as OrderStatus)) {
+      this.ordersService.updateOrderStatus(order.id, status as OrderStatus);
+    }
+  }
+
+  goBack(): void {
+    this.router.navigate(['/dashboard', 'sales']);
+  }
 }

--- a/src/app/orders/pages/orders/orders.component.css
+++ b/src/app/orders/pages/orders/orders.component.css
@@ -1,0 +1,84 @@
+.orders-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+  color: #1f1f1f;
+}
+
+.orders-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.orders-page__header h1 {
+  margin: 0;
+  font-size: 2.25rem;
+  font-weight: 700;
+}
+
+.orders-page__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: #5a5a5a;
+}
+
+.orders-page__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, #6a1b9a, #8e24aa);
+  color: #ffffff;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 8px 20px rgba(110, 39, 129, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.orders-page__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(110, 39, 129, 0.35);
+}
+
+.orders-page__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, #ffffff, #f3ecff);
+  box-shadow: 0 12px 24px rgba(126, 76, 178, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary-card__label {
+  font-size: 0.85rem;
+  color: #5b2a86;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.summary-card__value {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  .orders-page {
+    padding: 1.5rem;
+  }
+
+  .orders-page__header h1 {
+    font-size: 1.8rem;
+  }
+}

--- a/src/app/orders/pages/orders/orders.component.html
+++ b/src/app/orders/pages/orders/orders.component.html
@@ -1,1 +1,26 @@
-<p>orders works!</p>
+<section class="orders-page">
+  <header class="orders-page__header">
+    <div>
+      <h1>Pedidos</h1>
+      <p class="orders-page__subtitle">Administra el ciclo completo de ventas y el estado de cada pedido.</p>
+    </div>
+    <a class="orders-page__cta" routerLink="/dashboard/sales/new">Crear pedido</a>
+  </header>
+
+  <section class="orders-page__summary" *ngIf="summary$ | async as summary">
+    <article class="summary-card">
+      <span class="summary-card__label">Pedidos totales</span>
+      <strong class="summary-card__value">{{ summary.totalOrders }}</strong>
+    </article>
+    <article class="summary-card">
+      <span class="summary-card__label">Ingresos acumulados</span>
+      <strong class="summary-card__value">{{ summary.totalRevenue | currency:'USD':'symbol':'1.0-0' }}</strong>
+    </article>
+    <article class="summary-card" *ngFor="let status of summaryStatuses">
+      <span class="summary-card__label">{{ statusLabels[status] }}</span>
+      <strong class="summary-card__value">{{ summary.byStatus[status] }}</strong>
+    </article>
+  </section>
+
+  <app-order-list></app-order-list>
+</section>

--- a/src/app/orders/pages/orders/orders.component.ts
+++ b/src/app/orders/pages/orders/orders.component.ts
@@ -1,12 +1,51 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+import { OrdersService } from '../../services/orders.service';
+import { OrderStatus } from '../../models/order.entity';
 import { OrderListComponent } from '../../components/order-list/order-list.component';
+
+interface OrdersSummary {
+  totalOrders: number;
+  totalRevenue: number;
+  byStatus: Record<OrderStatus, number>;
+}
 
 @Component({
   selector: 'app-orders',
   standalone: true,
-  imports: [CommonModule, OrderListComponent],
+  imports: [CommonModule, RouterModule, OrderListComponent],
   templateUrl: './orders.component.html',
   styleUrls: ['./orders.component.css']
 })
-export class OrdersComponent {}
+export class OrdersComponent {
+  private readonly ordersService = inject(OrdersService);
+
+  readonly summary$ = this.ordersService.getOrders().pipe(
+    map(orders => {
+      const byStatus = orders.reduce<OrdersSummary['byStatus']>((acc, order) => {
+        acc[order.status] = (acc[order.status] ?? 0) + 1;
+        return acc;
+      }, { pending: 0, processing: 0, completed: 0, cancelled: 0 });
+
+      const totalRevenue = orders.reduce((acc, order) => acc + order.total, 0);
+
+      return {
+        totalOrders: orders.length,
+        totalRevenue,
+        byStatus
+      } satisfies OrdersSummary;
+    })
+  );
+
+  readonly statusLabels: Record<OrderStatus, string> = {
+    pending: 'Pendiente',
+    processing: 'En preparación',
+    completed: 'Completado',
+    cancelled: 'Cancelado'
+  };
+
+  readonly summaryStatuses: OrderStatus[] = ['pending', 'processing', 'completed', 'cancelled'];
+}

--- a/src/app/orders/services/catalog.service.ts
+++ b/src/app/orders/services/catalog.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import { CatalogItem, MOCK_CATALOG_ITEMS } from '../models/catalog-item.entity';
+
+@Injectable({ providedIn: 'root' })
+export class CatalogService {
+  private readonly catalogSubject = new BehaviorSubject<CatalogItem[]>([...MOCK_CATALOG_ITEMS]);
+
+  getCatalog(): Observable<CatalogItem[]> {
+    return this.catalogSubject.asObservable();
+  }
+
+  getCatalogSnapshot(): CatalogItem[] {
+    return this.catalogSubject.getValue();
+  }
+
+  findById(id: string): CatalogItem | undefined {
+    return this.getCatalogSnapshot().find(item => item.id === id);
+  }
+}

--- a/src/app/orders/services/orders.service.ts
+++ b/src/app/orders/services/orders.service.ts
@@ -1,0 +1,186 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { CatalogService } from './catalog.service';
+import { CatalogItem } from '../models/catalog-item.entity';
+import { NewOrderInput, Order, OrderItem, OrderStatus } from '../models/order.entity';
+
+const TAX_RATE = 0.19;
+
+@Injectable({ providedIn: 'root' })
+export class OrdersService {
+  private readonly catalogService = inject(CatalogService);
+  private readonly ordersSubject = new BehaviorSubject<Order[]>([]);
+
+  constructor() {
+    const seededOrders = this.createSeedOrders();
+    this.ordersSubject.next(seededOrders);
+  }
+
+  getOrders(): Observable<Order[]> {
+    return this.ordersSubject.asObservable();
+  }
+
+  getOrderById(orderId: string): Observable<Order | undefined> {
+    return this.ordersSubject.pipe(map(orders => orders.find(order => order.id === orderId)));
+  }
+
+  createOrder(input: NewOrderInput): Order {
+    const orderId = this.generateOrderId();
+    const items = input.items.map((item, index) => this.createOrderItemFromCatalogId(orderId, index, item.catalogItemId, item.quantity));
+    const totals = this.calculateTotals(items);
+    const newOrder: Order = {
+      id: orderId,
+      code: this.generateOrderCode(),
+      customerName: input.customerName,
+      customerEmail: input.customerEmail,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      expectedDelivery: this.computeExpectedDeliveryDate(),
+      notes: input.notes,
+      items,
+      ...totals
+    };
+
+    this.ordersSubject.next([...this.ordersSubject.getValue(), newOrder]);
+    return newOrder;
+  }
+
+  updateOrderStatus(orderId: string, status: OrderStatus): void {
+    const orders = this.ordersSubject.getValue();
+    const index = orders.findIndex(order => order.id === orderId);
+    if (index === -1) {
+      return;
+    }
+
+    const updatedOrder: Order = { ...orders[index], status };
+    const updatedOrders = [...orders];
+    updatedOrders.splice(index, 1, updatedOrder);
+    this.ordersSubject.next(updatedOrders);
+  }
+
+  private createSeedOrders(): Order[] {
+    const catalog = this.catalogService.getCatalogSnapshot();
+    const firstOrderItems = [
+      this.tryCreateOrderItem('ord-0001', 0, catalog[0], 6),
+      this.tryCreateOrderItem('ord-0001', 1, catalog[2], 3)
+    ].filter(Boolean) as OrderItem[];
+
+    const secondOrderItems = [
+      this.tryCreateOrderItem('ord-0002', 0, catalog[1], 12),
+      this.tryCreateOrderItem('ord-0002', 1, catalog[4], 8)
+    ].filter(Boolean) as OrderItem[];
+
+    const thirdOrderItems = [
+      this.tryCreateOrderItem('ord-0003', 0, catalog[1], 20)
+    ].filter(Boolean) as OrderItem[];
+
+    const firstTotals = this.calculateTotals(firstOrderItems);
+    const secondTotals = this.calculateTotals(secondOrderItems);
+    const thirdTotals = this.calculateTotals(thirdOrderItems);
+
+    return [
+      {
+        id: 'ord-0001',
+        code: 'WI-2025-001',
+        customerName: 'Restaurante La Vid',
+        customerEmail: 'compras@lavid.com',
+        status: 'processing',
+        createdAt: this.createPastDate(3),
+        expectedDelivery: this.createFutureDate(2),
+        notes: 'Entrega en horario matutino.',
+        items: firstOrderItems,
+        ...firstTotals
+      },
+      {
+        id: 'ord-0002',
+        code: 'WI-2025-002',
+        customerName: 'Bodega El Roble',
+        customerEmail: 'contacto@elroble.ar',
+        status: 'completed',
+        createdAt: this.createPastDate(10),
+        expectedDelivery: this.createPastDate(3),
+        notes: 'Pedido recurrente mensual.',
+        items: secondOrderItems,
+        ...secondTotals
+      },
+      {
+        id: 'ord-0003',
+        code: 'WI-2025-003',
+        customerName: 'Wine Lovers Club',
+        customerEmail: 'compras@wineloversclub.es',
+        status: 'pending',
+        createdAt: this.createPastDate(1),
+        expectedDelivery: this.createFutureDate(5),
+        notes: 'Confirmar disponibilidad del Malbec 2019.',
+        items: thirdOrderItems,
+        ...thirdTotals
+      }
+    ];
+  }
+
+  private tryCreateOrderItem(orderId: string, index: number, catalogItem: CatalogItem | undefined, quantity: number): OrderItem | null {
+    if (!catalogItem) {
+      return null;
+    }
+
+    return this.createOrderItem(orderId, index, catalogItem, quantity);
+  }
+
+  private createOrderItem(orderId: string, index: number, catalogItem: CatalogItem, quantity: number): OrderItem {
+    const safeQuantity = Math.max(1, quantity);
+    const unitPrice = catalogItem.price;
+    const lineTotal = unitPrice * safeQuantity;
+
+    return {
+      id: `${orderId}-item-${index + 1}`,
+      catalogItem,
+      quantity: safeQuantity,
+      unitPrice,
+      lineTotal
+    };
+  }
+
+  private createOrderItemFromCatalogId(orderId: string, index: number, catalogItemId: string, quantity: number): OrderItem {
+    const catalogItem = this.catalogService.findById(catalogItemId);
+    if (!catalogItem) {
+      throw new Error(`El artículo con id ${catalogItemId} no existe en el catálogo.`);
+    }
+
+    return this.createOrderItem(orderId, index, catalogItem, quantity);
+  }
+
+  private calculateTotals(items: OrderItem[]): Pick<Order, 'subtotal' | 'tax' | 'total'> {
+    const subtotal = items.reduce((acc, item) => acc + item.lineTotal, 0);
+    const tax = Math.round(subtotal * TAX_RATE * 100) / 100;
+    const total = Math.round((subtotal + tax) * 100) / 100;
+    return { subtotal, tax, total };
+  }
+
+  private generateOrderId(): string {
+    return `ord-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  private generateOrderCode(): string {
+    const year = new Date().getFullYear();
+    const sequential = (this.ordersSubject.getValue().length + 1).toString().padStart(3, '0');
+    return `WI-${year}-${sequential}`;
+  }
+
+  private computeExpectedDeliveryDate(): string {
+    return this.createFutureDate(4);
+  }
+
+  private createPastDate(daysAgo: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() - daysAgo);
+    return date.toISOString();
+  }
+
+  private createFutureDate(daysAhead: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() + daysAhead);
+    return date.toISOString();
+  }
+}


### PR DESCRIPTION
## Summary
- add order and catalog models plus services with seeded data and creation helpers
- build orders listing, detail and creation pages with standalone components and styling
- configure dashboard routing to expose the sales/orders workflow

## Testing
- npm run build *(fails: font inlining request to fonts.googleapis.com returned 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68dec59017888320b96bd0e195e5bedc