### PR TITLE
feat(orders): load data from local json server

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -1,3 +1,171 @@
 {
-
+  "catalog": [
+    {
+      "id": "cab-2018",
+      "name": "Gran Reserva Cabernet Sauvignon",
+      "varietal": "Cabernet Sauvignon",
+      "vintage": 2018,
+      "origin": "Napa Valley, USA",
+      "price": 58,
+      "imageUrl": "https://images.unsplash.com/photo-1543248939-ff40856f65d4",
+      "tastingNotes": "Notas de cassis, vainilla y roble tostado con taninos redondos."
+    },
+    {
+      "id": "mal-2019",
+      "name": "Alturas Andinas Malbec",
+      "varietal": "Malbec",
+      "vintage": 2019,
+      "origin": "Mendoza, Argentina",
+      "price": 42,
+      "imageUrl": "https://images.unsplash.com/photo-1543248986-42142f9b6043",
+      "tastingNotes": "Frutos rojos maduros, especias dulces y final persistente."
+    },
+    {
+      "id": "cha-2020",
+      "name": "Costa Dorada Chardonnay",
+      "varietal": "Chardonnay",
+      "vintage": 2020,
+      "origin": "Casablanca, Chile",
+      "price": 36,
+      "imageUrl": "https://images.unsplash.com/photo-1514533450685-26ef7784906e",
+      "tastingNotes": "Aromas cítricos, mantequilla fresca y delicado tostado."
+    },
+    {
+      "id": "tem-2017",
+      "name": "Viña Antigua Tempranillo",
+      "varietal": "Tempranillo",
+      "vintage": 2017,
+      "origin": "Rioja, España",
+      "price": 49,
+      "imageUrl": "https://images.unsplash.com/photo-1527169402691-feff5539e52c",
+      "tastingNotes": "Ciruelas maduras, tabaco y notas de cuero envejecido."
+    },
+    {
+      "id": "ros-2022",
+      "name": "Rosé Mediterráneo",
+      "varietal": "Grenache",
+      "vintage": 2022,
+      "origin": "Provenza, Francia",
+      "price": 24,
+      "imageUrl": "https://images.unsplash.com/photo-1527169402991-3546847d86be",
+      "tastingNotes": "Refrescante, floral y con un delicado toque mineral."
+    }
+  ],
+  "orders": [
+    {
+      "id": "ord-0001",
+      "code": "WI-2025-001",
+      "customerName": "Restaurante La Vid",
+      "customerEmail": "compras@lavid.com",
+      "status": "processing",
+      "createdAt": "2025-02-20T09:30:00.000Z",
+      "expectedDelivery": "2025-02-24T09:30:00.000Z",
+      "notes": "Entrega en horario matutino.",
+      "items": [
+        {
+          "id": "ord-0001-item-1",
+          "catalogItem": {
+            "id": "cab-2018",
+            "name": "Gran Reserva Cabernet Sauvignon",
+            "varietal": "Cabernet Sauvignon",
+            "vintage": 2018,
+            "origin": "Napa Valley, USA",
+            "price": 58
+          },
+          "quantity": 6,
+          "unitPrice": 58,
+          "lineTotal": 348
+        },
+        {
+          "id": "ord-0001-item-2",
+          "catalogItem": {
+            "id": "cha-2020",
+            "name": "Costa Dorada Chardonnay",
+            "varietal": "Chardonnay",
+            "vintage": 2020,
+            "origin": "Casablanca, Chile",
+            "price": 36
+          },
+          "quantity": 3,
+          "unitPrice": 36,
+          "lineTotal": 108
+        }
+      ],
+      "subtotal": 456,
+      "tax": 86.64,
+      "total": 542.64
+    },
+    {
+      "id": "ord-0002",
+      "code": "WI-2025-002",
+      "customerName": "Bodega El Roble",
+      "customerEmail": "contacto@elroble.ar",
+      "status": "completed",
+      "createdAt": "2025-02-13T11:15:00.000Z",
+      "expectedDelivery": "2025-02-17T09:00:00.000Z",
+      "notes": "Pedido recurrente mensual.",
+      "items": [
+        {
+          "id": "ord-0002-item-1",
+          "catalogItem": {
+            "id": "mal-2019",
+            "name": "Alturas Andinas Malbec",
+            "varietal": "Malbec",
+            "vintage": 2019,
+            "origin": "Mendoza, Argentina",
+            "price": 42
+          },
+          "quantity": 12,
+          "unitPrice": 42,
+          "lineTotal": 504
+        },
+        {
+          "id": "ord-0002-item-2",
+          "catalogItem": {
+            "id": "ros-2022",
+            "name": "Rosé Mediterráneo",
+            "varietal": "Grenache",
+            "vintage": 2022,
+            "origin": "Provenza, Francia",
+            "price": 24
+          },
+          "quantity": 8,
+          "unitPrice": 24,
+          "lineTotal": 192
+        }
+      ],
+      "subtotal": 696,
+      "tax": 132.24,
+      "total": 828.24
+    },
+    {
+      "id": "ord-0003",
+      "code": "WI-2025-003",
+      "customerName": "Wine Lovers Club",
+      "customerEmail": "compras@wineloversclub.es",
+      "status": "pending",
+      "createdAt": "2025-02-22T15:45:00.000Z",
+      "expectedDelivery": "2025-02-27T15:45:00.000Z",
+      "notes": "Confirmar disponibilidad del Malbec 2019.",
+      "items": [
+        {
+          "id": "ord-0003-item-1",
+          "catalogItem": {
+            "id": "mal-2019",
+            "name": "Alturas Andinas Malbec",
+            "varietal": "Malbec",
+            "vintage": 2019,
+            "origin": "Mendoza, Argentina",
+            "price": 42
+          },
+          "quantity": 20,
+          "unitPrice": 42,
+          "lineTotal": 840
+        }
+      ],
+      "subtotal": 840,
+      "tax": 159.6,
+      "total": 999.6
+    }
+  ]
 }

--- a/src/app/orders/pages/new-order/new-order.component.ts
+++ b/src/app/orders/pages/new-order/new-order.component.ts
@@ -91,8 +91,10 @@ export class NewOrderComponent implements OnInit {
       }))
     };
 
-    this.ordersService.createOrder(payload);
-    this.router.navigate(['/dashboard', 'sales']);
+    this.ordersService.createOrder(payload).subscribe({
+      next: () => this.router.navigate(['/dashboard', 'sales']),
+      error: error => console.error('No se pudo crear la orden.', error)
+    });
   }
 
   trackByIndex(index: number): number {

--- a/src/app/orders/pages/order-detail/order-detail.component.ts
+++ b/src/app/orders/pages/order-detail/order-detail.component.ts
@@ -40,7 +40,9 @@ export class OrderDetailComponent {
 
   updateStatus(order: Order, status: string): void {
     if (this.statusOptions.includes(status as OrderStatus)) {
-      this.ordersService.updateOrderStatus(order.id, status as OrderStatus);
+      this.ordersService.updateOrderStatus(order.id, status as OrderStatus).subscribe({
+        error: error => console.error('No se pudo actualizar el estado de la orden.', error)
+      });
     }
   }
 

--- a/src/app/orders/services/catalog.service.ts
+++ b/src/app/orders/services/catalog.service.ts
@@ -1,11 +1,19 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
 
-import { CatalogItem, MOCK_CATALOG_ITEMS } from '../models/catalog-item.entity';
+import { CatalogItem } from '../models/catalog-item.entity';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class CatalogService {
-  private readonly catalogSubject = new BehaviorSubject<CatalogItem[]>([...MOCK_CATALOG_ITEMS]);
+  private readonly http = inject(HttpClient);
+  private readonly catalogSubject = new BehaviorSubject<CatalogItem[]>([]);
+  private readonly catalogEndpoint = `${environment.apiUrl}/catalog`;
+
+  constructor() {
+    this.refreshCatalog().subscribe();
+  }
 
   getCatalog(): Observable<CatalogItem[]> {
     return this.catalogSubject.asObservable();
@@ -17,5 +25,14 @@ export class CatalogService {
 
   findById(id: string): CatalogItem | undefined {
     return this.getCatalogSnapshot().find(item => item.id === id);
+  }
+
+  refreshCatalog(): Observable<CatalogItem[]> {
+    return this.http.get<CatalogItem[]>(this.catalogEndpoint).pipe(
+      tap({
+        next: catalog => this.catalogSubject.next(catalog),
+        error: error => console.error('No se pudo cargar el catálogo de productos.', error)
+      })
+    );
   }
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  production: true,
+  production: false,
   apiUrl: 'http://localhost:3000/api/v1',
   baseServerUrl: 'http://localhost:8080/api/v1',
 };


### PR DESCRIPTION
## Summary
- seed the local json-server database with catalog and order fixtures used by the sales views
- replace the in-memory catalog and orders logic with HTTP-backed services that read and persist against the db.json API
- adapt order creation and status update flows to wait for server responses and correct development environment settings

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ded0757ee48320b2444fca94792ee1