### PR TITLE
feat: persist complete order details from client

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
+    "json-server": "^0.17.4",
     "typescript": "~5.7.2"
   }
 }

--- a/src/app/orders/models/order.entity.ts
+++ b/src/app/orders/models/order.entity.ts
@@ -34,5 +34,8 @@ export interface NewOrderInput {
   customerName: string;
   customerEmail?: string;
   notes?: string;
+  status: OrderStatus;
+  createdAt: string;
+  expectedDelivery: string;
   items: NewOrderItemInput[];
 }

--- a/src/app/orders/pages/new-order/new-order.component.html
+++ b/src/app/orders/pages/new-order/new-order.component.html
@@ -35,6 +35,39 @@
     </section>
 
     <section class="form-section">
+      <h2>Información del pedido</h2>
+      <div class="form-grid">
+        <label class="form-field">
+          <span>Fecha de creación *</span>
+          <input type="datetime-local" formControlName="createdAt" />
+          <small class="error" *ngIf="orderForm.get('createdAt')?.touched && orderForm.get('createdAt')?.hasError('required')">
+            Este campo es obligatorio.
+          </small>
+        </label>
+        <label class="form-field">
+          <span>Fecha de entrega *</span>
+          <input type="datetime-local" formControlName="expectedDelivery" [min]="orderForm.get('createdAt')?.value || undefined" />
+          <small class="error" *ngIf="orderForm.get('expectedDelivery')?.touched && orderForm.get('expectedDelivery')?.hasError('required')">
+            Este campo es obligatorio.
+          </small>
+          <small class="error" *ngIf="orderForm.hasError('deliveryBeforeCreation') && orderForm.get('expectedDelivery')?.touched">
+            La fecha de entrega no puede ser anterior a la fecha de creación.
+          </small>
+        </label>
+        <label class="form-field">
+          <span>Estado *</span>
+          <select formControlName="status">
+            <option [ngValue]="null" disabled>Selecciona un estado</option>
+            <option *ngFor="let status of statusOptions" [ngValue]="status">{{ statusLabels[status] }}</option>
+          </select>
+          <small class="error" *ngIf="orderForm.get('status')?.touched && orderForm.get('status')?.hasError('required')">
+            Selecciona un estado para el pedido.
+          </small>
+        </label>
+      </div>
+    </section>
+
+    <section class="form-section">
       <div class="section-header">
         <h2>Detalle del pedido</h2>
         <button type="button" (click)="addItem()">Agregar producto</button>


### PR DESCRIPTION
## Summary
- build complete order payloads on the client so new records persisted via json-server already contain catalog details, totals, and timestamps
- validate scheduling, status, and catalog lookups locally before sending the order to the backend
- restore the dev scripts to start the backend with `json-server --watch db.json --routes routes.json`

## Testing
- npm run build *(fails: ng: not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dfe8fe4088832980be9e541c1bfe10