### PR TITLE
feat: implement profile dashboard experience

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ const SignInComponent = () => import('./authentication/pages/sign-in/sign-in.com
 const SignUpComponent = () => import('./authentication/pages/sign-up/sign-up.component').then(m => m.SignUpComponent);
 const DashboardComponent = () => import('./shared/presentation/view/dashboard/dashboard.component').then(m => m.DashboardComponent);
 const PageNotFoundComponent = () => import('./shared/presentation/view/page-not-found/page-not-found.component').then(m => m.PageNotFoundComponent);
+const ProfileComponent = () => import('./profile/pages/profile/profile.component').then(m => m.ProfileComponent);
 
 const baseTitle = 'WineInventory';
 
@@ -11,6 +12,7 @@ export const routes: Routes = [
   { path: '', redirectTo: 'sign-in', pathMatch: 'full' },
   { path: 'sign-in', loadComponent: SignInComponent, data: { title: `${baseTitle} | Sign In` } },
   { path: 'sign-up', loadComponent: SignUpComponent, data: { title: `${baseTitle} | Sign Up` } },
+  { path: 'profile', loadComponent: ProfileComponent, data: { title: `${baseTitle} | Profile` } },
   {
     path: 'dashboard',
     loadComponent: DashboardComponent,

--- a/src/app/profile/pages/profile/profile.component.css
+++ b/src/app/profile/pages/profile/profile.component.css
@@ -1,0 +1,650 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: linear-gradient(120deg, #1b1322 0%, #22162b 100%);
+  color: #f7f1ff;
+  font-family: 'Roboto', sans-serif;
+}
+
+.profile-layout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  font-size: 20px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  background: rgba(33, 18, 38, 0.95);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 32px 24px;
+  gap: 32px;
+}
+
+.sidebar__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.brand__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(150deg, #f9a66b 0%, #fecd9f 100%);
+  color: #2a0e1d;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 1px;
+}
+
+.brand__name {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 240, 224, 0.72);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nav-button {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  background: transparent;
+  color: rgba(255, 245, 235, 0.8);
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.nav-button:hover {
+  background: rgba(255, 215, 180, 0.12);
+  border-color: rgba(255, 215, 180, 0.2);
+  color: #fff7f0;
+}
+
+.nav-button--active {
+  background: rgba(255, 215, 180, 0.18);
+  border-color: rgba(255, 215, 180, 0.45);
+  color: #fff9f3;
+  box-shadow: 0 10px 25px -15px rgba(255, 174, 126, 0.6);
+}
+
+.nav-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: rgba(255, 215, 180, 0.15);
+  color: #f9be80;
+  font-size: 18px;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__hint {
+  font-size: 12px;
+  color: rgba(255, 245, 235, 0.55);
+}
+
+.workspace {
+  padding: 48px 56px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.workspace__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 24px 32px;
+}
+
+.header__title {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.header__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(255, 215, 180, 0.18);
+  color: #f7b16e;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+}
+
+.header__title h1 {
+  margin: 0 0 4px;
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.header__title p {
+  margin: 0;
+  color: rgba(255, 245, 235, 0.72);
+}
+
+.header__status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(92, 233, 188, 0.4);
+  background: rgba(92, 233, 188, 0.12);
+  color: #9ff2d1;
+  font-weight: 600;
+}
+
+.workspace__grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 24px;
+}
+
+.card {
+  background: rgba(30, 17, 33, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 28px;
+  padding: 32px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 25px 45px -30px rgba(12, 7, 16, 0.9);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.card__header p {
+  margin: 6px 0 0;
+  color: rgba(255, 245, 235, 0.72);
+  font-size: 14px;
+}
+
+.profile-card {
+  grid-column: span 8;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 24px;
+}
+
+.profile-card__user {
+  background: rgba(46, 28, 53, 0.7);
+  border-radius: 20px;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.avatar {
+  width: 86px;
+  height: 86px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, #fbd3a3 0%, #f7a26c 100%);
+  color: #2a0e1d;
+  font-size: 32px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-card__role {
+  margin: 0;
+  color: rgba(255, 245, 235, 0.7);
+}
+
+.profile-card__details {
+  width: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.profile-card__details div {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  text-align: left;
+  color: rgba(255, 245, 235, 0.8);
+}
+
+.profile-card__details dt {
+  margin: 0;
+  font-size: 20px;
+  color: #f8bd7e;
+}
+
+.profile-card__details dd {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.profile-card__form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px 24px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form-field label {
+  font-weight: 500;
+  color: rgba(255, 245, 235, 0.82);
+}
+
+.form-field input {
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(20, 9, 24, 0.8);
+  color: #fff7f0;
+  font-size: 15px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input::placeholder {
+  color: rgba(255, 245, 235, 0.45);
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: rgba(249, 182, 116, 0.8);
+  box-shadow: 0 0 0 3px rgba(249, 182, 116, 0.18);
+}
+
+.form-field--error input {
+  border-color: rgba(255, 126, 148, 0.9);
+  box-shadow: 0 0 0 3px rgba(255, 126, 148, 0.12);
+}
+
+.field-error {
+  font-size: 12px;
+  color: #ff9ba8;
+}
+
+.password-group {
+  position: relative;
+}
+
+.form-actions {
+  grid-column: span 2;
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  font-weight: 600;
+  border-radius: 14px;
+  padding: 12px 24px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(150deg, #f7a26c 0%, #fbd3a3 100%);
+  color: #2a0e1d;
+  box-shadow: 0 12px 24px -10px rgba(247, 162, 108, 0.65);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px -12px rgba(247, 162, 108, 0.75);
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #fff7f0;
+}
+
+.secondary-button:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.ghost-button {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 245, 235, 0.85);
+}
+
+.ghost-button:hover {
+  border-color: rgba(249, 182, 116, 0.5);
+  color: #fff7f0;
+}
+
+.account-card {
+  grid-column: span 4;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.status-chip--active {
+  background: rgba(132, 255, 206, 0.12);
+  border: 1px solid rgba(132, 255, 206, 0.35);
+  color: #9ff2d1;
+}
+
+.account-card__plan {
+  margin: 0 0 10px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.account-card__subtitle {
+  margin: 0 0 24px;
+  color: rgba(255, 245, 235, 0.72);
+  font-size: 14px;
+}
+
+.account-card__actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.account-card__support {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 245, 235, 0.7);
+}
+
+.account-card__support a {
+  color: #f9be80;
+  text-decoration: none;
+}
+
+.account-card__support a:hover {
+  text-decoration: underline;
+}
+
+.plans-card {
+  grid-column: span 8;
+}
+
+.plans-card__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.plan {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(36, 20, 41, 0.85);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.plan:hover {
+  border-color: rgba(249, 182, 116, 0.6);
+  transform: translateY(-4px);
+  box-shadow: 0 20px 35px -25px rgba(249, 182, 116, 0.8);
+}
+
+.plan--selected {
+  border-color: rgba(249, 182, 116, 0.85);
+  box-shadow: 0 24px 40px -22px rgba(249, 182, 116, 0.8);
+  background: linear-gradient(150deg, rgba(249, 182, 116, 0.15) 0%, rgba(249, 182, 116, 0.05) 100%);
+}
+
+.plan__header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.plan__price {
+  font-size: 22px;
+  font-weight: 600;
+  color: #f9be80;
+}
+
+.plan__price small {
+  font-size: 12px;
+  color: rgba(255, 245, 235, 0.6);
+}
+
+.plan__description {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 245, 235, 0.75);
+}
+
+.plan__benefits {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.plan__benefits li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: rgba(255, 245, 235, 0.85);
+}
+
+.plan__benefits .material-symbols-outlined {
+  color: #9ff2d1;
+  font-size: 18px;
+}
+
+.plan__cta {
+  margin-top: auto;
+  font-weight: 600;
+  color: #f9be80;
+}
+
+.benefits-card {
+  grid-column: span 4;
+}
+
+.benefits-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.benefits-card__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  color: rgba(255, 245, 235, 0.78);
+}
+
+.benefits-card__list .material-symbols-outlined {
+  font-size: 18px;
+  color: #f7b16e;
+  margin-top: 2px;
+}
+
+@media (max-width: 1260px) {
+  .profile-layout {
+    grid-template-columns: 230px minmax(0, 1fr);
+  }
+
+  .profile-card {
+    grid-column: span 12;
+  }
+
+  .account-card {
+    grid-column: span 6;
+  }
+
+  .plans-card {
+    grid-column: span 12;
+  }
+
+  .benefits-card {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 992px) {
+  .profile-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 28px;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .sidebar__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .nav-button {
+    flex: 1 1 120px;
+  }
+
+  .workspace {
+    padding: 32px 24px 48px;
+  }
+
+  .workspace__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .profile-card__form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .form-actions {
+    grid-column: span 1;
+    justify-content: stretch;
+  }
+
+  .form-actions button {
+    flex: 1;
+  }
+
+  .account-card,
+  .benefits-card {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 680px) {
+  .workspace {
+    padding: 24px 16px 40px;
+  }
+
+  .workspace__grid {
+    gap: 18px;
+  }
+
+  .card {
+    padding: 24px;
+  }
+
+  .sidebar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .sidebar__nav {
+    width: 100%;
+    gap: 8px;
+  }
+
+  .nav-button {
+    width: 100%;
+  }
+}

--- a/src/app/profile/pages/profile/profile.component.html
+++ b/src/app/profile/pages/profile/profile.component.html
@@ -1,1 +1,182 @@
-<p>profile works!</p>
+<div class="profile-layout">
+  <aside class="sidebar">
+    <div class="sidebar__brand">
+      <span class="brand__logo">WI</span>
+      <span class="brand__name">WineInventory</span>
+    </div>
+    <nav class="sidebar__nav">
+      <button
+        *ngFor="let link of sidebarLinks"
+        type="button"
+        class="nav-button"
+        [class.nav-button--active]="link.active"
+      >
+        <span class="nav-button__icon material-symbols-outlined">{{ link.icon }}</span>
+        <span class="nav-button__label">{{ link.label }}</span>
+      </button>
+    </nav>
+    <div class="sidebar__footer">
+      <p class="sidebar__hint">Actualizado hace 5 min</p>
+      <button type="button" class="secondary-button">Cerrar sesión</button>
+    </div>
+  </aside>
+
+  <section class="workspace">
+    <header class="workspace__header">
+      <div class="header__title">
+        <div class="header__icon material-symbols-outlined">badge</div>
+        <div>
+          <h1>Perfil</h1>
+          <p>Gestiona tu información personal, credenciales y plan de suscripción.</p>
+        </div>
+      </div>
+      <div class="header__status-chip">
+        <span class="material-symbols-outlined">verified</span>
+        Cuenta verificada
+      </div>
+    </header>
+
+    <div class="workspace__grid">
+      <article class="card profile-card">
+        <div class="profile-card__user">
+          <div class="avatar">JP</div>
+          <h2>{{ userProfile.fullName }}</h2>
+          <p class="profile-card__role">{{ userProfile.role }}</p>
+          <dl class="profile-card__details">
+            <div>
+              <dt class="material-symbols-outlined">mail</dt>
+              <dd>{{ userProfile.email }}</dd>
+            </div>
+            <div>
+              <dt class="material-symbols-outlined">call</dt>
+              <dd>{{ userProfile.phone }}</dd>
+            </div>
+            <div>
+              <dt class="material-symbols-outlined">location_on</dt>
+              <dd>{{ userProfile.location }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <form class="profile-card__form" [formGroup]="profileForm" (ngSubmit)="submitProfileForm()">
+          <div class="form-field" [class.form-field--error]="isFieldInvalid('fullName')">
+            <label for="fullName">Nombre</label>
+            <input id="fullName" type="text" formControlName="fullName" placeholder="Ingresa tu nombre completo" />
+            <span class="field-error" *ngIf="isFieldInvalid('fullName')">
+              Debe contener al menos 3 caracteres.
+            </span>
+          </div>
+
+          <div class="form-field" [class.form-field--error]="isFieldInvalid('email')">
+            <label for="email">Correo electrónico</label>
+            <input id="email" type="email" formControlName="email" placeholder="correo@empresa.com" />
+            <span class="field-error" *ngIf="isFieldInvalid('email')">
+              Ingresa un correo electrónico válido.
+            </span>
+          </div>
+
+          <div class="form-field" [class.form-field--error]="isFieldInvalid('username')">
+            <label for="username">Nombre de usuario</label>
+            <input id="username" type="text" formControlName="username" placeholder="usuario" />
+            <span class="field-error" *ngIf="isFieldInvalid('username')">
+              Debe contener al menos 4 caracteres.
+            </span>
+          </div>
+
+          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('currentPassword')">
+            <label for="currentPassword">Contraseña actual</label>
+            <input id="currentPassword" type="password" formControlName="currentPassword" placeholder="••••••" />
+            <span class="field-error" *ngIf="isFieldInvalid('currentPassword')">
+              La contraseña debe tener al menos 6 caracteres.
+            </span>
+          </div>
+
+          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('newPassword')">
+            <label for="newPassword">Nueva contraseña</label>
+            <input id="newPassword" type="password" formControlName="newPassword" placeholder="••••••" />
+            <span class="field-error" *ngIf="isFieldInvalid('newPassword')">
+              La contraseña debe tener al menos 6 caracteres.
+            </span>
+          </div>
+
+          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('confirmPassword')">
+            <label for="confirmPassword">Confirmar contraseña</label>
+            <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="••••••" />
+            <span class="field-error" *ngIf="isFieldInvalid('confirmPassword')">
+              La contraseña debe tener al menos 6 caracteres.
+            </span>
+          </div>
+
+          <div class="form-actions">
+            <button type="button" class="secondary-button">Cancelar</button>
+            <button type="submit" class="primary-button">Guardar cambios</button>
+          </div>
+        </form>
+      </article>
+
+      <article class="card account-card">
+        <header class="card__header">
+          <h2>Tipo de cuenta</h2>
+          <span class="status-chip status-chip--active">
+            <span class="material-symbols-outlined">workspace_premium</span>
+            {{ accountStatus.statusLabel }}
+          </span>
+        </header>
+        <div class="account-card__body">
+          <p class="account-card__plan">{{ accountStatus.planName }}</p>
+          <p class="account-card__subtitle">Tu plan se renovará automáticamente el {{ accountStatus.renewalDate }}.</p>
+          <div class="account-card__actions">
+            <button type="button" class="primary-button">Actualizar plan</button>
+            <button type="button" class="ghost-button">Contactar soporte</button>
+          </div>
+          <p class="account-card__support">
+            ¿Necesitas ayuda? Escríbenos a
+            <a href="mailto:{{ accountStatus.supportContact }}">{{ accountStatus.supportContact }}</a>.
+          </p>
+        </div>
+      </article>
+
+      <article class="card plans-card">
+        <header class="card__header">
+          <h2>Planes</h2>
+          <p>Selecciona el plan que mejor se adapte al crecimiento de tu bodega.</p>
+        </header>
+        <div class="plans-card__grid">
+          <button
+            *ngFor="let plan of plans"
+            type="button"
+            class="plan"
+            [class.plan--selected]="selectedPlanId() === plan.id"
+            (click)="selectPlan(plan.id)"
+          >
+            <div class="plan__header">
+              <h3>{{ plan.name }}</h3>
+              <span class="plan__price">{{ plan.price }}<small>/mes</small></span>
+            </div>
+            <p class="plan__description">{{ plan.shortDescription }}</p>
+            <ul class="plan__benefits">
+              <li *ngFor="let benefit of plan.benefits">
+                <span class="material-symbols-outlined">check_circle</span>
+                {{ benefit }}
+              </li>
+            </ul>
+            <span class="plan__cta">Elegir este plan</span>
+          </button>
+        </div>
+      </article>
+
+      <article class="card benefits-card">
+        <header class="card__header">
+          <h2>Beneficios del Plan Premium</h2>
+          <p>Aprovecha al máximo la versión más completa del sistema.</p>
+        </header>
+        <ul class="benefits-card__list">
+          <li *ngFor="let benefit of premiumBenefits">
+            <span class="material-symbols-outlined">star</span>
+            {{ benefit }}
+          </li>
+        </ul>
+      </article>
+    </div>
+  </section>
+</div>

--- a/src/app/profile/pages/profile/profile.component.ts
+++ b/src/app/profile/pages/profile/profile.component.ts
@@ -1,11 +1,125 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+type AccountPlan = {
+  id: string;
+  name: string;
+  price: string;
+  shortDescription: string;
+  benefits: string[];
+};
+
+type AccountStatus = {
+  planName: string;
+  renewalDate: string;
+  supportContact: string;
+  statusLabel: string;
+};
+
+type ProfileFormField =
+  | 'fullName'
+  | 'email'
+  | 'username'
+  | 'currentPassword'
+  | 'newPassword'
+  | 'confirmPassword';
 
 @Component({
   selector: 'app-profile',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.css'
 })
 export class ProfileComponent {
+  readonly sidebarLinks = [
+    { icon: 'home', label: 'Inicio' },
+    { icon: 'person', label: 'Perfil', active: true },
+    { icon: 'inventory', label: 'Inventario' },
+    { icon: 'shopping_cart', label: 'Pedidos' },
+    { icon: 'bar_chart', label: 'Reportes' },
+    { icon: 'settings', label: 'Ajustes' }
+  ];
 
+  readonly userProfile = {
+    fullName: 'Juan Pérez',
+    role: 'Administrador General',
+    email: 'juanperez@email.com',
+    phone: '+52 55 1234 5678',
+    location: 'Ciudad de México, MX'
+  };
+
+  readonly accountStatus: AccountStatus = {
+    planName: 'Plan Premium',
+    renewalDate: '15 Marzo 2025',
+    supportContact: 'soporte@wineinventory.com',
+    statusLabel: 'Activo'
+  };
+
+  readonly plans: AccountPlan[] = [
+    {
+      id: 'starter',
+      name: 'Starter',
+      price: '$0',
+      shortDescription: 'Gestión básica para bodegas pequeñas.',
+      benefits: ['Inventario limitado', 'Reportes básicos', '1 usuario']
+    },
+    {
+      id: 'premium',
+      name: 'Premium',
+      price: '$18',
+      shortDescription: 'Herramientas avanzadas para crecer tu negocio.',
+      benefits: ['Inventario ilimitado', 'Reportes inteligentes', 'Soporte prioritario']
+    },
+    {
+      id: 'enterprise',
+      name: 'Enterprise',
+      price: '$39',
+      shortDescription: 'Automatización total y conexión con ERP.',
+      benefits: ['Integraciones avanzadas', 'Roles personalizados', 'Gerente de cuenta dedicado']
+    }
+  ];
+
+  readonly premiumBenefits = [
+    'Acceso a promociones exclusivas de distribuidores aliados',
+    'Alertas inteligentes sobre stock crítico y rotación de productos',
+    'Paneles personalizados para equipos de ventas y marketing',
+    'Integración directa con herramientas de facturación y CRM',
+    'Soporte prioritario 24/7 con especialistas en enología'
+  ];
+
+  readonly selectedPlanId = signal<AccountPlan['id']>('premium');
+
+  readonly profileForm: FormGroup;
+
+  constructor(private readonly formBuilder: FormBuilder) {
+    this.profileForm = this.formBuilder.group({
+      fullName: [this.userProfile.fullName, [Validators.required, Validators.minLength(3)]],
+      email: [this.userProfile.email, [Validators.required, Validators.email]],
+      username: ['jperez', [Validators.required, Validators.minLength(4)]],
+      currentPassword: ['', [Validators.minLength(6)]],
+      newPassword: ['', [Validators.minLength(6)]],
+      confirmPassword: ['', [Validators.minLength(6)]]
+    });
+  }
+
+  selectPlan(planId: AccountPlan['id']): void {
+    this.selectedPlanId.set(planId);
+  }
+
+  submitProfileForm(): void {
+    if (this.profileForm.invalid) {
+      this.profileForm.markAllAsTouched();
+      return;
+    }
+
+    // TODO: Integrar con el servicio real cuando esté disponible.
+    console.table(this.profileForm.value);
+  }
+
+  isFieldInvalid(fieldName: ProfileFormField): boolean {
+    const control = this.profileForm.get(fieldName);
+    return !!control && control.invalid && (control.dirty || control.touched);
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,10 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
+  >
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- build the standalone profile page with sidebar shortcuts, profile form, account status, plans, and benefits sections
- style the layout with the requested palette, responsive grid, and custom states for cards, buttons, and forms
- register the profile route and load the Material Symbols font for the outlined icons

## Testing
- npm run build *(fails: remote fonts return 403 in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e17984e088833098332412c0455071