### PR TITLE
feat(profile): add editable settings view with service

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -198,5 +198,66 @@
       "customerEmail": "sdfdsfs@f",
       "notes": "sdvsvsdvsv"
     }
+  ],
+  "profiles": [
+    {
+      "id": "current",
+      "fullName": "Juan Pérez",
+      "role": "Administrador General",
+      "email": "juanperez@email.com",
+      "phone": "+52 55 1234 5678",
+      "location": "Ciudad de México, MX",
+      "username": "jperez",
+      "accountStatus": {
+        "planName": "Plan Premium",
+        "renewalDate": "2025-03-15T00:00:00.000Z",
+        "supportContact": "soporte@wineinventory.com",
+        "statusLabel": "Activo"
+      },
+      "selectedPlanId": "premium",
+      "lastUpdated": "2025-02-20T15:30:00.000Z"
+    }
+  ],
+  "subscriptionPlans": [
+    {
+      "id": "starter",
+      "name": "Starter",
+      "price": "$0",
+      "shortDescription": "Gestión básica para bodegas pequeñas.",
+      "benefits": [
+        "Inventario limitado",
+        "Reportes básicos",
+        "1 usuario"
+      ]
+    },
+    {
+      "id": "premium",
+      "name": "Premium",
+      "price": "$18",
+      "shortDescription": "Herramientas avanzadas para crecer tu negocio.",
+      "benefits": [
+        "Inventario ilimitado",
+        "Reportes inteligentes",
+        "Soporte prioritario"
+      ]
+    },
+    {
+      "id": "enterprise",
+      "name": "Enterprise",
+      "price": "$39",
+      "shortDescription": "Automatización total y conexión con ERP.",
+      "benefits": [
+        "Integraciones avanzadas",
+        "Roles personalizados",
+        "Gerente de cuenta dedicado"
+      ]
+    }
+  ],
+  "premiumBenefits": [
+    "Acceso a promociones exclusivas de distribuidores aliados",
+    "Alertas inteligentes sobre stock crítico y rotación de productos",
+    "Paneles personalizados para equipos de ventas y marketing",
+    "Integración directa con herramientas de facturación y CRM",
+    "Soporte prioritario 24/7 con especialistas en enología"
   ]
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ export const routes: Routes = [
   { path: 'sign-in', loadComponent: SignInComponent, data: { title: `${baseTitle} | Sign In` } },
   { path: 'sign-up', loadComponent: SignUpComponent, data: { title: `${baseTitle} | Sign Up` } },
   { path: 'profile', loadComponent: ProfileComponent, data: { title: `${baseTitle} | Profile` } },
+  { path: 'profile/settings', loadComponent: ProfileComponent, data: { title: `${baseTitle} | Profile Settings` } },
   {
     path: 'dashboard',
     loadComponent: DashboardComponent,

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.css
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.css
@@ -1,0 +1,5 @@
+.benefits-card__empty {
+  margin: 0;
+  color: rgba(255, 245, 235, 0.7);
+  font-size: 14px;
+}

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.html
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.html
@@ -1,1 +1,17 @@
-<p>plan-benefits works!</p>
+<header class="card__header">
+  <h2>Beneficios del plan Premium</h2>
+  <p>Aprovecha al máximo la versión más completa del sistema.</p>
+</header>
+
+<ng-container *ngIf="benefits?.length; else noBenefits">
+  <ul class="benefits-card__list">
+    <li *ngFor="let benefit of benefits">
+      <span class="material-symbols-outlined">star</span>
+      {{ benefit }}
+    </li>
+  </ul>
+</ng-container>
+
+<ng-template #noBenefits>
+  <p class="benefits-card__empty">Aún no hay beneficios configurados.</p>
+</ng-template>

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.ts
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.ts
@@ -1,11 +1,16 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-plan-benefits',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './plan-benefits.component.html',
-  styleUrl: './plan-benefits.component.css'
+  styleUrl: './plan-benefits.component.css',
+  host: {
+    class: 'card benefits-card'
+  }
 })
 export class PlanBenefitsComponent {
-
+  @Input() benefits: string[] = [];
 }

--- a/src/app/profile/components/plan-details/plan-details.component.css
+++ b/src/app/profile/components/plan-details/plan-details.component.css
@@ -1,0 +1,10 @@
+:host button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.plan-details__empty {
+  margin: 0;
+  color: rgba(255, 245, 235, 0.7);
+  font-size: 14px;
+}

--- a/src/app/profile/components/plan-details/plan-details.component.html
+++ b/src/app/profile/components/plan-details/plan-details.component.html
@@ -1,1 +1,34 @@
-<p>plan-details works!</p>
+<header class="card__header">
+  <h2>Planes</h2>
+  <p>Selecciona el plan que mejor se adapte al crecimiento de tu bodega.</p>
+</header>
+
+<ng-container *ngIf="plans?.length; else emptyState">
+  <div class="plans-card__grid">
+    <button
+      *ngFor="let plan of plans"
+      type="button"
+      class="plan"
+      [class.plan--selected]="plan.id === selectedPlanId"
+      (click)="onSelectPlan(plan.id)"
+      [disabled]="disabled"
+    >
+      <div class="plan__header">
+        <h3>{{ plan.name }}</h3>
+        <span class="plan__price">{{ plan.price }}<small>/mes</small></span>
+      </div>
+      <p class="plan__description">{{ plan.shortDescription }}</p>
+      <ul class="plan__benefits">
+        <li *ngFor="let benefit of plan.benefits">
+          <span class="material-symbols-outlined">check_circle</span>
+          {{ benefit }}
+        </li>
+      </ul>
+      <span class="plan__cta">{{ plan.id === selectedPlanId ? 'Plan actual' : 'Elegir este plan' }}</span>
+    </button>
+  </div>
+</ng-container>
+
+<ng-template #emptyState>
+  <p class="plan-details__empty">No hay planes disponibles en este momento.</p>
+</ng-template>

--- a/src/app/profile/components/plan-details/plan-details.component.ts
+++ b/src/app/profile/components/plan-details/plan-details.component.ts
@@ -1,11 +1,29 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { SubscriptionPlan } from '../../models/profile.entity';
 
 @Component({
   selector: 'app-plan-details',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './plan-details.component.html',
-  styleUrl: './plan-details.component.css'
+  styleUrl: './plan-details.component.css',
+  host: {
+    class: 'card plans-card'
+  }
 })
 export class PlanDetailsComponent {
+  @Input() plans: SubscriptionPlan[] = [];
+  @Input() selectedPlanId: string | null = null;
+  @Input() disabled = false;
+  @Output() planSelected = new EventEmitter<string>();
 
+  onSelectPlan(planId: string): void {
+    if (this.disabled || this.selectedPlanId === planId) {
+      return;
+    }
+
+    this.planSelected.emit(planId);
+  }
 }

--- a/src/app/profile/components/profile-edit/profile-edit.component.html
+++ b/src/app/profile/components/profile-edit/profile-edit.component.html
@@ -1,1 +1,94 @@
-<p>profile-edit works!</p>
+<div class="profile-card__user" *ngIf="profile as profileData">
+  <div class="avatar">{{ avatarInitials }}</div>
+  <h2>{{ profileData.fullName }}</h2>
+  <p class="profile-card__role">{{ profileData.role }}</p>
+
+  <dl class="profile-card__details">
+    <div>
+      <dt class="material-symbols-outlined">mail</dt>
+      <dd>{{ profileData.email }}</dd>
+    </div>
+    <div>
+      <dt class="material-symbols-outlined">call</dt>
+      <dd>{{ profileData.phone }}</dd>
+    </div>
+    <div>
+      <dt class="material-symbols-outlined">location_on</dt>
+      <dd>{{ profileData.location }}</dd>
+    </div>
+  </dl>
+</div>
+
+<form class="profile-card__form" [formGroup]="profileForm" (ngSubmit)="submit()">
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('fullName')">
+    <label for="fullName">Nombre</label>
+    <input id="fullName" type="text" formControlName="fullName" placeholder="Ingresa tu nombre completo" />
+    <span class="field-error" *ngIf="isFieldInvalid('fullName')">
+      Debe contener al menos 3 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('email')">
+    <label for="email">Correo electrónico</label>
+    <input id="email" type="email" formControlName="email" placeholder="correo@empresa.com" />
+    <span class="field-error" *ngIf="isFieldInvalid('email')">
+      Ingresa un correo electrónico válido.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('username')">
+    <label for="username">Nombre de usuario</label>
+    <input id="username" type="text" formControlName="username" placeholder="usuario" />
+    <span class="field-error" *ngIf="isFieldInvalid('username')">
+      Debe contener al menos 4 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('phone')">
+    <label for="phone">Teléfono</label>
+    <input id="phone" type="tel" formControlName="phone" placeholder="Ingresa un número de contacto" />
+    <span class="field-error" *ngIf="isFieldInvalid('phone')">
+      Ingresa un teléfono válido.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('location')">
+    <label for="location">Ubicación</label>
+    <input id="location" type="text" formControlName="location" placeholder="Ciudad, País" />
+    <span class="field-error" *ngIf="isFieldInvalid('location')">
+      Ingresa una ubicación válida.
+    </span>
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('currentPassword')">
+    <label for="currentPassword">Contraseña actual</label>
+    <input id="currentPassword" type="password" formControlName="currentPassword" placeholder="••••••" />
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('newPassword')">
+    <label for="newPassword">Nueva contraseña</label>
+    <input id="newPassword" type="password" formControlName="newPassword" placeholder="••••••" />
+    <span class="field-error" *ngIf="isFieldInvalid('newPassword')">
+      La contraseña debe tener al menos 6 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('confirmPassword')">
+    <label for="confirmPassword">Confirmar contraseña</label>
+    <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="••••••" />
+    <span class="field-error" *ngIf="isFieldInvalid('confirmPassword')">
+      Las contraseñas deben coincidir.
+    </span>
+  </div>
+
+  <div class="form-actions">
+    <button type="button" class="secondary-button" (click)="resetForm()" [disabled]="saving">
+      Cancelar
+    </button>
+    <button type="submit" class="primary-button" [disabled]="saving">
+      {{ saving ? 'Guardando…' : 'Guardar cambios' }}
+    </button>
+  </div>
+
+  <p class="field-error" *ngIf="errorMessage">{{ errorMessage }}</p>
+</form>

--- a/src/app/profile/components/profile-edit/profile-edit.component.ts
+++ b/src/app/profile/components/profile-edit/profile-edit.component.ts
@@ -1,11 +1,123 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { Profile } from '../../models/profile.entity';
+
+export interface ProfileFormValue {
+  fullName: string;
+  email: string;
+  username: string;
+  phone: string;
+  location: string;
+}
 
 @Component({
   selector: 'app-profile-edit',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './profile-edit.component.html',
-  styleUrl: './profile-edit.component.css'
+  styleUrl: './profile-edit.component.css',
+  host: {
+    class: 'card profile-card'
+  }
 })
-export class ProfileEditComponent {
+export class ProfileEditComponent implements OnChanges {
+  @Input({ required: true }) profile!: Profile;
+  @Input() saving = false;
+  @Input() errorMessage: string | null = null;
 
+  @Output() saveProfile = new EventEmitter<ProfileFormValue>();
+  @Output() cancelEdit = new EventEmitter<void>();
+
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly profileForm: FormGroup = this.formBuilder.group({
+    fullName: ['', [Validators.required, Validators.minLength(3)]],
+    email: ['', [Validators.required, Validators.email]],
+    username: ['', [Validators.required, Validators.minLength(4)]],
+    phone: ['', [Validators.required, Validators.minLength(7)]],
+    location: ['', [Validators.required, Validators.minLength(3)]],
+    currentPassword: ['', []],
+    newPassword: ['', [Validators.minLength(6)]],
+    confirmPassword: ['', [Validators.minLength(6)]]
+  });
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['profile'] && this.profile) {
+      this.patchFormWithProfile(this.profile);
+    }
+  }
+
+  get avatarInitials(): string {
+    return this.computeInitials(this.profile?.fullName ?? '');
+  }
+
+  submit(): void {
+    if (this.profileForm.invalid || !this.ensurePasswordsMatch()) {
+      this.profileForm.markAllAsTouched();
+      return;
+    }
+
+    const { fullName, email, username, phone, location } = this.profileForm.value as ProfileFormValue;
+    this.saveProfile.emit({ fullName, email, username, phone, location });
+  }
+
+  resetForm(): void {
+    if (this.profile) {
+      this.patchFormWithProfile(this.profile);
+    }
+    this.profileForm.get('currentPassword')?.reset('');
+    this.profileForm.get('newPassword')?.reset('');
+    this.profileForm.get('confirmPassword')?.reset('');
+    this.cancelEdit.emit();
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const control = this.profileForm.get(fieldName);
+    return !!control && control.invalid && (control.dirty || control.touched);
+  }
+
+  private patchFormWithProfile(profile: Profile): void {
+    this.profileForm.patchValue({
+      fullName: profile.fullName,
+      email: profile.email,
+      username: profile.username,
+      phone: profile.phone,
+      location: profile.location
+    });
+  }
+
+  private computeInitials(fullName: string): string {
+    if (!fullName) {
+      return 'US';
+    }
+
+    const initials = fullName
+      .split(' ')
+      .filter(part => part.trim().length > 0)
+      .slice(0, 2)
+      .map(part => part.trim().charAt(0).toUpperCase())
+      .join('');
+
+    return initials || fullName.charAt(0).toUpperCase();
+  }
+
+  private ensurePasswordsMatch(): boolean {
+    const newPassword = this.profileForm.get('newPassword')?.value?.trim();
+    const confirmPassword = this.profileForm.get('confirmPassword')?.value?.trim();
+
+    if (!newPassword && !confirmPassword) {
+      this.profileForm.get('confirmPassword')?.setErrors(null);
+      return true;
+    }
+
+    if (newPassword !== confirmPassword) {
+      this.profileForm.get('confirmPassword')?.setErrors({ mismatch: true });
+      return false;
+    }
+
+    this.profileForm.get('confirmPassword')?.setErrors(null);
+    return true;
+  }
 }

--- a/src/app/profile/models/profile.entity.ts
+++ b/src/app/profile/models/profile.entity.ts
@@ -1,0 +1,38 @@
+export interface AccountStatus {
+  planName: string;
+  renewalDate: string;
+  supportContact: string;
+  statusLabel: string;
+}
+
+export interface Profile {
+  id: string;
+  fullName: string;
+  role: string;
+  email: string;
+  phone: string;
+  location: string;
+  username: string;
+  accountStatus: AccountStatus;
+  selectedPlanId: string;
+  lastUpdated?: string;
+}
+
+export interface SubscriptionPlan {
+  id: string;
+  name: string;
+  price: string;
+  shortDescription: string;
+  benefits: string[];
+}
+
+export interface ProfileUpdateInput {
+  fullName?: string;
+  email?: string;
+  username?: string;
+  phone?: string;
+  location?: string;
+  accountStatus?: Partial<AccountStatus>;
+  selectedPlanId?: string;
+  lastUpdated?: string;
+}

--- a/src/app/profile/pages/profile/profile.component.css
+++ b/src/app/profile/pages/profile/profile.component.css
@@ -73,6 +73,7 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
+  text-decoration: none;
 }
 
 .nav-button:hover {
@@ -175,6 +176,31 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 24px;
+}
+
+.workspace__error {
+  margin: 0;
+  color: #ff9ba8;
+  font-size: 14px;
+}
+
+.workspace__loading,
+.workspace__empty {
+  margin-top: 40px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 24px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 245, 235, 0.82);
+}
+
+.workspace__loading .material-symbols-outlined,
+.workspace__empty .material-symbols-outlined {
+  font-size: 24px;
+  color: #f9be80;
 }
 
 .card {

--- a/src/app/profile/pages/profile/profile.component.html
+++ b/src/app/profile/pages/profile/profile.component.html
@@ -4,19 +4,24 @@
       <span class="brand__logo">WI</span>
       <span class="brand__name">WineInventory</span>
     </div>
+
     <nav class="sidebar__nav">
-      <button
+      <a
         *ngFor="let link of sidebarLinks"
-        type="button"
         class="nav-button"
-        [class.nav-button--active]="link.active"
+        [routerLink]="link.route"
+        routerLinkActive="nav-button--active"
+        [routerLinkActiveOptions]="{ exact: link.exact ?? false }"
       >
         <span class="nav-button__icon material-symbols-outlined">{{ link.icon }}</span>
         <span class="nav-button__label">{{ link.label }}</span>
-      </button>
+      </a>
     </nav>
+
     <div class="sidebar__footer">
-      <p class="sidebar__hint">Actualizado hace 5 min</p>
+      <p class="sidebar__hint" *ngIf="profile()?.lastUpdated as lastUpdated">
+        Actualizado por última vez el {{ lastUpdated | date: 'dd MMMM yyyy, HH:mm' }}
+      </p>
       <button type="button" class="secondary-button">Cerrar sesión</button>
     </div>
   </aside>
@@ -26,157 +31,88 @@
       <div class="header__title">
         <div class="header__icon material-symbols-outlined">badge</div>
         <div>
-          <h1>Perfil</h1>
-          <p>Gestiona tu información personal, credenciales y plan de suscripción.</p>
+          <h1>{{ isSettingsView() ? 'Ajustes' : 'Perfil' }}</h1>
+          <p *ngIf="!isSettingsView()">Gestiona tu información personal, credenciales y plan de suscripción.</p>
+          <p *ngIf="isSettingsView()">Actualiza tus datos personales y preferencias de acceso.</p>
         </div>
       </div>
-      <div class="header__status-chip">
+
+      <div class="header__status-chip" *ngIf="accountStatus() as status">
         <span class="material-symbols-outlined">verified</span>
-        Cuenta verificada
+        {{ status.statusLabel }}
       </div>
     </header>
 
-    <div class="workspace__grid">
-      <article class="card profile-card">
-        <div class="profile-card__user">
-          <div class="avatar">JP</div>
-          <h2>{{ userProfile.fullName }}</h2>
-          <p class="profile-card__role">{{ userProfile.role }}</p>
-          <dl class="profile-card__details">
-            <div>
-              <dt class="material-symbols-outlined">mail</dt>
-              <dd>{{ userProfile.email }}</dd>
+    <p class="workspace__error" *ngIf="loadError() as errorMessage">{{ errorMessage }}</p>
+
+    <ng-container *ngIf="!isLoading(); else loading">
+      <ng-container *ngIf="profile() as currentProfile; else emptyProfile">
+        <div class="workspace__grid">
+          <app-profile-edit
+            [profile]="currentProfile"
+            [saving]="isSaving()"
+            [errorMessage]="updateError()"
+            (saveProfile)="handleProfileSave($event)"
+            (cancelEdit)="handleCancelEdit()"
+          ></app-profile-edit>
+
+          <article class="card account-card" *ngIf="accountStatus() as status">
+            <header class="card__header">
+              <h2>Tipo de cuenta</h2>
+              <span class="status-chip status-chip--active">
+                <span class="material-symbols-outlined">workspace_premium</span>
+                {{ status.statusLabel }}
+              </span>
+            </header>
+            <div class="account-card__body">
+              <p class="account-card__plan">{{ status.planName }}</p>
+              <p class="account-card__subtitle">
+                Tu plan se renovará automáticamente el {{ status.renewalDate | date: 'dd MMMM yyyy' }}.
+              </p>
+              <div class="account-card__actions">
+                <button
+                  type="button"
+                  class="primary-button"
+                  (click)="selectedPlanId() && handlePlanSelected(selectedPlanId()!)"
+                  [disabled]="isSaving() || !selectedPlanId()"
+                >
+                  Mantener plan actual
+                </button>
+                <button type="button" class="ghost-button" [disabled]="isSaving()">
+                  Contactar soporte
+                </button>
+              </div>
+              <p class="account-card__support">
+                ¿Necesitas ayuda? Escríbenos a
+                <a [href]="'mailto:' + status.supportContact">{{ status.supportContact }}</a>.
+              </p>
             </div>
-            <div>
-              <dt class="material-symbols-outlined">call</dt>
-              <dd>{{ userProfile.phone }}</dd>
-            </div>
-            <div>
-              <dt class="material-symbols-outlined">location_on</dt>
-              <dd>{{ userProfile.location }}</dd>
-            </div>
-          </dl>
+          </article>
+
+          <app-plan-details
+            [plans]="plans()"
+            [selectedPlanId]="selectedPlanId()"
+            [disabled]="isSaving()"
+            (planSelected)="handlePlanSelected($event)"
+          ></app-plan-details>
+
+          <app-plan-benefits [benefits]="premiumBenefits()"></app-plan-benefits>
         </div>
-
-        <form class="profile-card__form" [formGroup]="profileForm" (ngSubmit)="submitProfileForm()">
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('fullName')">
-            <label for="fullName">Nombre</label>
-            <input id="fullName" type="text" formControlName="fullName" placeholder="Ingresa tu nombre completo" />
-            <span class="field-error" *ngIf="isFieldInvalid('fullName')">
-              Debe contener al menos 3 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('email')">
-            <label for="email">Correo electrónico</label>
-            <input id="email" type="email" formControlName="email" placeholder="correo@empresa.com" />
-            <span class="field-error" *ngIf="isFieldInvalid('email')">
-              Ingresa un correo electrónico válido.
-            </span>
-          </div>
-
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('username')">
-            <label for="username">Nombre de usuario</label>
-            <input id="username" type="text" formControlName="username" placeholder="usuario" />
-            <span class="field-error" *ngIf="isFieldInvalid('username')">
-              Debe contener al menos 4 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('currentPassword')">
-            <label for="currentPassword">Contraseña actual</label>
-            <input id="currentPassword" type="password" formControlName="currentPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('currentPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('newPassword')">
-            <label for="newPassword">Nueva contraseña</label>
-            <input id="newPassword" type="password" formControlName="newPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('newPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('confirmPassword')">
-            <label for="confirmPassword">Confirmar contraseña</label>
-            <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('confirmPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-actions">
-            <button type="button" class="secondary-button">Cancelar</button>
-            <button type="submit" class="primary-button">Guardar cambios</button>
-          </div>
-        </form>
-      </article>
-
-      <article class="card account-card">
-        <header class="card__header">
-          <h2>Tipo de cuenta</h2>
-          <span class="status-chip status-chip--active">
-            <span class="material-symbols-outlined">workspace_premium</span>
-            {{ accountStatus.statusLabel }}
-          </span>
-        </header>
-        <div class="account-card__body">
-          <p class="account-card__plan">{{ accountStatus.planName }}</p>
-          <p class="account-card__subtitle">Tu plan se renovará automáticamente el {{ accountStatus.renewalDate }}.</p>
-          <div class="account-card__actions">
-            <button type="button" class="primary-button">Actualizar plan</button>
-            <button type="button" class="ghost-button">Contactar soporte</button>
-          </div>
-          <p class="account-card__support">
-            ¿Necesitas ayuda? Escríbenos a
-            <a href="mailto:{{ accountStatus.supportContact }}">{{ accountStatus.supportContact }}</a>.
-          </p>
-        </div>
-      </article>
-
-      <article class="card plans-card">
-        <header class="card__header">
-          <h2>Planes</h2>
-          <p>Selecciona el plan que mejor se adapte al crecimiento de tu bodega.</p>
-        </header>
-        <div class="plans-card__grid">
-          <button
-            *ngFor="let plan of plans"
-            type="button"
-            class="plan"
-            [class.plan--selected]="selectedPlanId() === plan.id"
-            (click)="selectPlan(plan.id)"
-          >
-            <div class="plan__header">
-              <h3>{{ plan.name }}</h3>
-              <span class="plan__price">{{ plan.price }}<small>/mes</small></span>
-            </div>
-            <p class="plan__description">{{ plan.shortDescription }}</p>
-            <ul class="plan__benefits">
-              <li *ngFor="let benefit of plan.benefits">
-                <span class="material-symbols-outlined">check_circle</span>
-                {{ benefit }}
-              </li>
-            </ul>
-            <span class="plan__cta">Elegir este plan</span>
-          </button>
-        </div>
-      </article>
-
-      <article class="card benefits-card">
-        <header class="card__header">
-          <h2>Beneficios del Plan Premium</h2>
-          <p>Aprovecha al máximo la versión más completa del sistema.</p>
-        </header>
-        <ul class="benefits-card__list">
-          <li *ngFor="let benefit of premiumBenefits">
-            <span class="material-symbols-outlined">star</span>
-            {{ benefit }}
-          </li>
-        </ul>
-      </article>
-    </div>
+      </ng-container>
+    </ng-container>
   </section>
 </div>
+
+<ng-template #loading>
+  <div class="workspace__loading">
+    <span class="material-symbols-outlined">hourglass_empty</span>
+    Cargando información del perfil…
+  </div>
+</ng-template>
+
+<ng-template #emptyProfile>
+  <div class="workspace__empty">
+    <span class="material-symbols-outlined">person_off</span>
+    No encontramos información del perfil para mostrar.
+  </div>
+</ng-template>

--- a/src/app/profile/pages/profile/profile.component.ts
+++ b/src/app/profile/pages/profile/profile.component.ts
@@ -1,125 +1,154 @@
-import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, computed, inject, signal } from '@angular/core';
+import { NavigationEnd, Router, RouterModule } from '@angular/router';
+import { finalize, filter } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-type AccountPlan = {
-  id: string;
-  name: string;
-  price: string;
-  shortDescription: string;
-  benefits: string[];
-};
+import { PlanBenefitsComponent } from '../../components/plan-benefits/plan-benefits.component';
+import { PlanDetailsComponent } from '../../components/plan-details/plan-details.component';
+import { ProfileEditComponent, ProfileFormValue } from '../../components/profile-edit/profile-edit.component';
+import { ProfileService } from '../../services/profile.service';
+import { AccountStatus, Profile, ProfileUpdateInput, SubscriptionPlan } from '../../models/profile.entity';
 
-type AccountStatus = {
-  planName: string;
-  renewalDate: string;
-  supportContact: string;
-  statusLabel: string;
-};
-
-type ProfileFormField =
-  | 'fullName'
-  | 'email'
-  | 'username'
-  | 'currentPassword'
-  | 'newPassword'
-  | 'confirmPassword';
+interface SidebarLink {
+  icon: string;
+  label: string;
+  route: string;
+  exact?: boolean;
+}
 
 @Component({
   selector: 'app-profile',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, RouterModule, ProfileEditComponent, PlanDetailsComponent, PlanBenefitsComponent],
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.css'
 })
 export class ProfileComponent {
-  readonly sidebarLinks = [
-    { icon: 'home', label: 'Inicio' },
-    { icon: 'person', label: 'Perfil', active: true },
-    { icon: 'inventory', label: 'Inventario' },
-    { icon: 'shopping_cart', label: 'Pedidos' },
-    { icon: 'bar_chart', label: 'Reportes' },
-    { icon: 'settings', label: 'Ajustes' }
+  private readonly profileService = inject(ProfileService);
+  private readonly router = inject(Router);
+
+  readonly sidebarLinks: SidebarLink[] = [
+    { icon: 'home', label: 'Inicio', route: '/dashboard' },
+    { icon: 'person', label: 'Perfil', route: '/profile', exact: true },
+    { icon: 'inventory', label: 'Inventario', route: '/inventory' },
+    { icon: 'shopping_cart', label: 'Pedidos', route: '/dashboard/sales' },
+    { icon: 'bar_chart', label: 'Reportes', route: '/reporting' },
+    { icon: 'settings', label: 'Ajustes', route: '/profile/settings' }
   ];
 
-  readonly userProfile = {
-    fullName: 'Juan Pérez',
-    role: 'Administrador General',
-    email: 'juanperez@email.com',
-    phone: '+52 55 1234 5678',
-    location: 'Ciudad de México, MX'
-  };
+  readonly profile = signal<Profile | null>(null);
+  readonly plans = signal<SubscriptionPlan[]>([]);
+  readonly premiumBenefits = signal<string[]>([]);
+  readonly isLoading = signal(false);
+  readonly isSaving = signal(false);
+  readonly loadError = signal<string | null>(null);
+  readonly updateError = signal<string | null>(null);
+  readonly isSettingsView = signal(false);
 
-  readonly accountStatus: AccountStatus = {
-    planName: 'Plan Premium',
-    renewalDate: '15 Marzo 2025',
-    supportContact: 'soporte@wineinventory.com',
-    statusLabel: 'Activo'
-  };
+  readonly accountStatus = computed<AccountStatus | null>(() => this.profile()?.accountStatus ?? null);
+  readonly selectedPlanId = computed<string | null>(() => this.profile()?.selectedPlanId ?? null);
 
-  readonly plans: AccountPlan[] = [
-    {
-      id: 'starter',
-      name: 'Starter',
-      price: '$0',
-      shortDescription: 'Gestión básica para bodegas pequeñas.',
-      benefits: ['Inventario limitado', 'Reportes básicos', '1 usuario']
-    },
-    {
-      id: 'premium',
-      name: 'Premium',
-      price: '$18',
-      shortDescription: 'Herramientas avanzadas para crecer tu negocio.',
-      benefits: ['Inventario ilimitado', 'Reportes inteligentes', 'Soporte prioritario']
-    },
-    {
-      id: 'enterprise',
-      name: 'Enterprise',
-      price: '$39',
-      shortDescription: 'Automatización total y conexión con ERP.',
-      benefits: ['Integraciones avanzadas', 'Roles personalizados', 'Gerente de cuenta dedicado']
-    }
-  ];
+  constructor() {
+    this.profileService
+      .getProfile()
+      .pipe(takeUntilDestroyed())
+      .subscribe(profile => this.profile.set(profile));
 
-  readonly premiumBenefits = [
-    'Acceso a promociones exclusivas de distribuidores aliados',
-    'Alertas inteligentes sobre stock crítico y rotación de productos',
-    'Paneles personalizados para equipos de ventas y marketing',
-    'Integración directa con herramientas de facturación y CRM',
-    'Soporte prioritario 24/7 con especialistas en enología'
-  ];
+    this.profileService
+      .getPlans()
+      .pipe(takeUntilDestroyed())
+      .subscribe(plans => this.plans.set(plans));
 
-  readonly selectedPlanId = signal<AccountPlan['id']>('premium');
+    this.profileService
+      .getPremiumBenefits()
+      .pipe(takeUntilDestroyed())
+      .subscribe(benefits => this.premiumBenefits.set(benefits));
 
-  readonly profileForm: FormGroup;
+    this.router.events
+      .pipe(
+        takeUntilDestroyed(),
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd)
+      )
+      .subscribe(event => this.evaluateView(event.urlAfterRedirects));
 
-  constructor(private readonly formBuilder: FormBuilder) {
-    this.profileForm = this.formBuilder.group({
-      fullName: [this.userProfile.fullName, [Validators.required, Validators.minLength(3)]],
-      email: [this.userProfile.email, [Validators.required, Validators.email]],
-      username: ['jperez', [Validators.required, Validators.minLength(4)]],
-      currentPassword: ['', [Validators.minLength(6)]],
-      newPassword: ['', [Validators.minLength(6)]],
-      confirmPassword: ['', [Validators.minLength(6)]]
-    });
+    this.evaluateView(this.router.url);
+    this.fetchInitialData();
   }
 
-  selectPlan(planId: AccountPlan['id']): void {
-    this.selectedPlanId.set(planId);
+  fetchInitialData(): void {
+    this.isLoading.set(true);
+    this.loadError.set(null);
+
+    this.profileService
+      .refreshAll()
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        error: () => this.loadError.set('No se pudieron cargar los datos del perfil. Intenta nuevamente más tarde.')
+      });
   }
 
-  submitProfileForm(): void {
-    if (this.profileForm.invalid) {
-      this.profileForm.markAllAsTouched();
+  handleProfileSave(formValue: ProfileFormValue): void {
+    this.updateError.set(null);
+    this.isSaving.set(true);
+
+    this.profileService
+      .updateProfile({
+        ...formValue,
+        lastUpdated: new Date().toISOString()
+      })
+      .pipe(finalize(() => this.isSaving.set(false)))
+      .subscribe({
+        error: () =>
+          this.updateError.set('No pudimos guardar tus cambios en este momento. Vuelve a intentarlo más tarde.')
+      });
+  }
+
+  handleCancelEdit(): void {
+    this.updateError.set(null);
+  }
+
+  handlePlanSelected(planId: string): void {
+    if (this.selectedPlanId() === planId) {
       return;
     }
 
-    // TODO: Integrar con el servicio real cuando esté disponible.
-    console.table(this.profileForm.value);
+    const payload = this.buildPlanUpdatePayload(planId);
+    if (!payload) {
+      return;
+    }
+
+    this.updateError.set(null);
+    this.isSaving.set(true);
+
+    this.profileService
+      .updateProfile(payload)
+      .pipe(finalize(() => this.isSaving.set(false)))
+      .subscribe({
+        error: () => this.updateError.set('No fue posible actualizar el plan seleccionado. Intenta nuevamente.')
+      });
   }
 
-  isFieldInvalid(fieldName: ProfileFormField): boolean {
-    const control = this.profileForm.get(fieldName);
-    return !!control && control.invalid && (control.dirty || control.touched);
+  private buildPlanUpdatePayload(planId: string): ProfileUpdateInput | null {
+    const currentProfile = this.profile();
+    if (!currentProfile) {
+      return null;
+    }
+
+    const payload: ProfileUpdateInput = {
+      selectedPlanId: planId,
+      lastUpdated: new Date().toISOString()
+    };
+
+    const nextStatus = this.profileService.buildAccountStatusForPlan(planId);
+    if (nextStatus) {
+      payload.accountStatus = nextStatus;
+    }
+
+    return payload;
+  }
+
+  private evaluateView(url: string): void {
+    this.isSettingsView.set(url.includes('/profile/settings'));
   }
 }

--- a/src/app/profile/services/profile.service.ts
+++ b/src/app/profile/services/profile.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, forkJoin, throwError } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+import { environment } from '../../../environments/environment';
+import { AccountStatus, Profile, ProfileUpdateInput, SubscriptionPlan } from '../models/profile.entity';
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private readonly http = inject(HttpClient);
+
+  private readonly profileEndpoint = `${environment.apiUrl}/profiles`;
+  private readonly plansEndpoint = `${environment.apiUrl}/subscriptionPlans`;
+  private readonly benefitsEndpoint = `${environment.apiUrl}/premiumBenefits`;
+  private readonly profileId = 'current';
+
+  private readonly profileSubject = new BehaviorSubject<Profile | null>(null);
+  private readonly plansSubject = new BehaviorSubject<SubscriptionPlan[]>([]);
+  private readonly benefitsSubject = new BehaviorSubject<string[]>([]);
+
+  getProfile(): Observable<Profile | null> {
+    return this.profileSubject.asObservable();
+  }
+
+  getPlans(): Observable<SubscriptionPlan[]> {
+    return this.plansSubject.asObservable();
+  }
+
+  getPremiumBenefits(): Observable<string[]> {
+    return this.benefitsSubject.asObservable();
+  }
+
+  refreshProfile(): Observable<Profile> {
+    return this.http.get<Profile>(`${this.profileEndpoint}/${this.profileId}`).pipe(
+      tap({
+        next: profile => this.profileSubject.next(profile),
+        error: error => console.error('No se pudo cargar el perfil.', error)
+      })
+    );
+  }
+
+  refreshPlans(): Observable<SubscriptionPlan[]> {
+    return this.http.get<SubscriptionPlan[]>(this.plansEndpoint).pipe(
+      tap({
+        next: plans => this.plansSubject.next(plans),
+        error: error => console.error('No se pudieron cargar los planes.', error)
+      })
+    );
+  }
+
+  refreshBenefits(): Observable<string[]> {
+    return this.http.get<string[]>(this.benefitsEndpoint).pipe(
+      tap({
+        next: benefits => this.benefitsSubject.next(benefits),
+        error: error => console.error('No se pudieron cargar los beneficios del plan.', error)
+      })
+    );
+  }
+
+  refreshAll(): Observable<{ profile: Profile; plans: SubscriptionPlan[]; benefits: string[] }> {
+    return forkJoin({
+      profile: this.refreshProfile(),
+      plans: this.refreshPlans(),
+      benefits: this.refreshBenefits()
+    });
+  }
+
+  updateProfile(changes: ProfileUpdateInput): Observable<Profile> {
+    if (!changes || typeof changes !== 'object') {
+      return throwError(() => new Error('Los cambios proporcionados no son válidos.'));
+    }
+
+    return this.http.patch<Profile>(`${this.profileEndpoint}/${this.profileId}`, changes).pipe(
+      tap({
+        next: profile => this.profileSubject.next(profile),
+        error: error => console.error('No se pudo actualizar el perfil.', error)
+      })
+    );
+  }
+
+  getProfileSnapshot(): Profile | null {
+    return this.profileSubject.getValue();
+  }
+
+  getPlansSnapshot(): SubscriptionPlan[] {
+    return this.plansSubject.getValue();
+  }
+
+  getBenefitsSnapshot(): string[] {
+    return this.benefitsSubject.getValue();
+  }
+
+  buildAccountStatusForPlan(planId: string): AccountStatus | null {
+    const profile = this.profileSubject.getValue();
+    const plans = this.plansSubject.getValue();
+    if (!profile || plans.length === 0) {
+      return null;
+    }
+
+    const selectedPlan = plans.find(plan => plan.id === planId);
+    if (!selectedPlan) {
+      return profile.accountStatus;
+    }
+
+    return {
+      ...profile.accountStatus,
+      planName: selectedPlan.name,
+      statusLabel: profile.accountStatus.statusLabel || 'Activo'
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- create profile models and services to retrieve and persist user data from the mock API
- build dedicated profile edit, plan details and benefits components and wire them into the profile page with routing for the settings view
- seed the json-server database with profile and subscription data to enable editing and plan selection persistence

## Testing
- npm run build *(fails: Inlining of fonts failed with status code 403 from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_68e18d84a54483309f329ca166727835