### PR TITLE
refactor: keep profile settings within dashboard layout

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -198,5 +198,66 @@
       "customerEmail": "sdfdsfs@f",
       "notes": "sdvsvsdvsv"
     }
+  ],
+  "profiles": [
+    {
+      "id": "current",
+      "fullName": "Juan Pérez",
+      "role": "Administrador General",
+      "email": "juanperez@email.com",
+      "phone": "+52 55 1234 5678",
+      "location": "Ciudad de México, MX",
+      "username": "jperez",
+      "accountStatus": {
+        "planName": "Plan Premium",
+        "renewalDate": "2025-03-15T00:00:00.000Z",
+        "supportContact": "soporte@wineinventory.com",
+        "statusLabel": "Activo"
+      },
+      "selectedPlanId": "premium",
+      "lastUpdated": "2025-02-20T15:30:00.000Z"
+    }
+  ],
+  "subscriptionPlans": [
+    {
+      "id": "starter",
+      "name": "Starter",
+      "price": "$0",
+      "shortDescription": "Gestión básica para bodegas pequeñas.",
+      "benefits": [
+        "Inventario limitado",
+        "Reportes básicos",
+        "1 usuario"
+      ]
+    },
+    {
+      "id": "premium",
+      "name": "Premium",
+      "price": "$18",
+      "shortDescription": "Herramientas avanzadas para crecer tu negocio.",
+      "benefits": [
+        "Inventario ilimitado",
+        "Reportes inteligentes",
+        "Soporte prioritario"
+      ]
+    },
+    {
+      "id": "enterprise",
+      "name": "Enterprise",
+      "price": "$39",
+      "shortDescription": "Automatización total y conexión con ERP.",
+      "benefits": [
+        "Integraciones avanzadas",
+        "Roles personalizados",
+        "Gerente de cuenta dedicado"
+      ]
+    }
+  ],
+  "premiumBenefits": [
+    "Acceso a promociones exclusivas de distribuidores aliados",
+    "Alertas inteligentes sobre stock crítico y rotación de productos",
+    "Paneles personalizados para equipos de ventas y marketing",
+    "Integración directa con herramientas de facturación y CRM",
+    "Soporte prioritario 24/7 con especialistas en enología"
   ]
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,13 +12,21 @@ export const routes: Routes = [
   { path: '', redirectTo: 'sign-in', pathMatch: 'full' },
   { path: 'sign-in', loadComponent: SignInComponent, data: { title: `${baseTitle} | Sign In` } },
   { path: 'sign-up', loadComponent: SignUpComponent, data: { title: `${baseTitle} | Sign Up` } },
-  { path: 'profile', loadComponent: ProfileComponent, data: { title: `${baseTitle} | Profile` } },
+  { path: 'profile', redirectTo: 'dashboard/profile', pathMatch: 'full' },
+  { path: 'profile/settings', redirectTo: 'dashboard/profile/settings', pathMatch: 'full' },
   {
     path: 'dashboard',
     loadComponent: DashboardComponent,
     children: [
       { path: '', redirectTo: 'sales', pathMatch: 'full' },
-      { path: 'sales', loadChildren: () => import('./orders/orders.routes').then(m => m.ORDERS_ROUTES) }
+      { path: 'sales', loadChildren: () => import('./orders/orders.routes').then(m => m.ORDERS_ROUTES) },
+      { path: 'profile', loadComponent: ProfileComponent, data: { title: `${baseTitle} | Profile` } },
+      {
+        path: 'profile/settings',
+        loadComponent: ProfileComponent,
+        data: { title: `${baseTitle} | Profile Settings` }
+      },
+      { path: 'settings', redirectTo: 'profile/settings', pathMatch: 'full' }
     ]
   },
   { path: '**', loadComponent: PageNotFoundComponent, data: { title: `${baseTitle} | Page Not Found` } }

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.css
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.css
@@ -1,0 +1,5 @@
+.benefits-card__empty {
+  margin: 0;
+  color: #5c6270;
+  font-size: 0.95rem;
+}

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.html
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.html
@@ -1,1 +1,17 @@
-<p>plan-benefits works!</p>
+<header class="card__header">
+  <h2>Beneficios del plan Premium</h2>
+  <p>Aprovecha al máximo la versión más completa del sistema.</p>
+</header>
+
+<ng-container *ngIf="benefits?.length; else noBenefits">
+  <ul class="benefits-card__list">
+    <li *ngFor="let benefit of benefits">
+      <span class="material-symbols-outlined">star</span>
+      {{ benefit }}
+    </li>
+  </ul>
+</ng-container>
+
+<ng-template #noBenefits>
+  <p class="benefits-card__empty">Aún no hay beneficios configurados.</p>
+</ng-template>

--- a/src/app/profile/components/plan-benefits/plan-benefits.component.ts
+++ b/src/app/profile/components/plan-benefits/plan-benefits.component.ts
@@ -1,11 +1,16 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-plan-benefits',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './plan-benefits.component.html',
-  styleUrl: './plan-benefits.component.css'
+  styleUrl: './plan-benefits.component.css',
+  host: {
+    class: 'card benefits-card'
+  }
 })
 export class PlanBenefitsComponent {
-
+  @Input() benefits: string[] = [];
 }

--- a/src/app/profile/components/plan-details/plan-details.component.css
+++ b/src/app/profile/components/plan-details/plan-details.component.css
@@ -1,0 +1,10 @@
+:host button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.plan-details__empty {
+  margin: 0;
+  color: #5c6270;
+  font-size: 0.95rem;
+}

--- a/src/app/profile/components/plan-details/plan-details.component.html
+++ b/src/app/profile/components/plan-details/plan-details.component.html
@@ -1,1 +1,34 @@
-<p>plan-details works!</p>
+<header class="card__header">
+  <h2>Planes</h2>
+  <p>Selecciona el plan que mejor se adapte al crecimiento de tu bodega.</p>
+</header>
+
+<ng-container *ngIf="plans?.length; else emptyState">
+  <div class="plans-card__grid">
+    <button
+      *ngFor="let plan of plans"
+      type="button"
+      class="plan"
+      [class.plan--selected]="plan.id === selectedPlanId"
+      (click)="onSelectPlan(plan.id)"
+      [disabled]="disabled"
+    >
+      <div class="plan__header">
+        <h3>{{ plan.name }}</h3>
+        <span class="plan__price">{{ plan.price }}<small>/mes</small></span>
+      </div>
+      <p class="plan__description">{{ plan.shortDescription }}</p>
+      <ul class="plan__benefits">
+        <li *ngFor="let benefit of plan.benefits">
+          <span class="material-symbols-outlined">check_circle</span>
+          {{ benefit }}
+        </li>
+      </ul>
+      <span class="plan__cta">{{ plan.id === selectedPlanId ? 'Plan actual' : 'Elegir este plan' }}</span>
+    </button>
+  </div>
+</ng-container>
+
+<ng-template #emptyState>
+  <p class="plan-details__empty">No hay planes disponibles en este momento.</p>
+</ng-template>

--- a/src/app/profile/components/plan-details/plan-details.component.ts
+++ b/src/app/profile/components/plan-details/plan-details.component.ts
@@ -1,11 +1,29 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { SubscriptionPlan } from '../../models/profile.entity';
 
 @Component({
   selector: 'app-plan-details',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './plan-details.component.html',
-  styleUrl: './plan-details.component.css'
+  styleUrl: './plan-details.component.css',
+  host: {
+    class: 'card plans-card'
+  }
 })
 export class PlanDetailsComponent {
+  @Input() plans: SubscriptionPlan[] = [];
+  @Input() selectedPlanId: string | null = null;
+  @Input() disabled = false;
+  @Output() planSelected = new EventEmitter<string>();
 
+  onSelectPlan(planId: string): void {
+    if (this.disabled || this.selectedPlanId === planId) {
+      return;
+    }
+
+    this.planSelected.emit(planId);
+  }
 }

--- a/src/app/profile/components/profile-edit/profile-edit.component.html
+++ b/src/app/profile/components/profile-edit/profile-edit.component.html
@@ -1,1 +1,94 @@
-<p>profile-edit works!</p>
+<div class="profile-card__user" *ngIf="profile as profileData">
+  <div class="avatar">{{ avatarInitials }}</div>
+  <h2>{{ profileData.fullName }}</h2>
+  <p class="profile-card__role">{{ profileData.role }}</p>
+
+  <dl class="profile-card__details">
+    <div>
+      <dt class="material-symbols-outlined">mail</dt>
+      <dd>{{ profileData.email }}</dd>
+    </div>
+    <div>
+      <dt class="material-symbols-outlined">call</dt>
+      <dd>{{ profileData.phone }}</dd>
+    </div>
+    <div>
+      <dt class="material-symbols-outlined">location_on</dt>
+      <dd>{{ profileData.location }}</dd>
+    </div>
+  </dl>
+</div>
+
+<form class="profile-card__form" [formGroup]="profileForm" (ngSubmit)="submit()">
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('fullName')">
+    <label for="fullName">Nombre</label>
+    <input id="fullName" type="text" formControlName="fullName" placeholder="Ingresa tu nombre completo" />
+    <span class="field-error" *ngIf="isFieldInvalid('fullName')">
+      Debe contener al menos 3 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('email')">
+    <label for="email">Correo electrónico</label>
+    <input id="email" type="email" formControlName="email" placeholder="correo@empresa.com" />
+    <span class="field-error" *ngIf="isFieldInvalid('email')">
+      Ingresa un correo electrónico válido.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('username')">
+    <label for="username">Nombre de usuario</label>
+    <input id="username" type="text" formControlName="username" placeholder="usuario" />
+    <span class="field-error" *ngIf="isFieldInvalid('username')">
+      Debe contener al menos 4 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('phone')">
+    <label for="phone">Teléfono</label>
+    <input id="phone" type="tel" formControlName="phone" placeholder="Ingresa un número de contacto" />
+    <span class="field-error" *ngIf="isFieldInvalid('phone')">
+      Ingresa un teléfono válido.
+    </span>
+  </div>
+
+  <div class="form-field" [class.form-field--error]="isFieldInvalid('location')">
+    <label for="location">Ubicación</label>
+    <input id="location" type="text" formControlName="location" placeholder="Ciudad, País" />
+    <span class="field-error" *ngIf="isFieldInvalid('location')">
+      Ingresa una ubicación válida.
+    </span>
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('currentPassword')">
+    <label for="currentPassword">Contraseña actual</label>
+    <input id="currentPassword" type="password" formControlName="currentPassword" placeholder="••••••" />
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('newPassword')">
+    <label for="newPassword">Nueva contraseña</label>
+    <input id="newPassword" type="password" formControlName="newPassword" placeholder="••••••" />
+    <span class="field-error" *ngIf="isFieldInvalid('newPassword')">
+      La contraseña debe tener al menos 6 caracteres.
+    </span>
+  </div>
+
+  <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('confirmPassword')">
+    <label for="confirmPassword">Confirmar contraseña</label>
+    <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="••••••" />
+    <span class="field-error" *ngIf="isFieldInvalid('confirmPassword')">
+      Las contraseñas deben coincidir.
+    </span>
+  </div>
+
+  <div class="form-actions">
+    <button type="button" class="secondary-button" (click)="resetForm()" [disabled]="saving">
+      Cancelar
+    </button>
+    <button type="submit" class="primary-button" [disabled]="saving">
+      {{ saving ? 'Guardando…' : 'Guardar cambios' }}
+    </button>
+  </div>
+
+  <p class="field-error" *ngIf="errorMessage">{{ errorMessage }}</p>
+</form>

--- a/src/app/profile/components/profile-edit/profile-edit.component.ts
+++ b/src/app/profile/components/profile-edit/profile-edit.component.ts
@@ -1,11 +1,123 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { Profile } from '../../models/profile.entity';
+
+export interface ProfileFormValue {
+  fullName: string;
+  email: string;
+  username: string;
+  phone: string;
+  location: string;
+}
 
 @Component({
   selector: 'app-profile-edit',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './profile-edit.component.html',
-  styleUrl: './profile-edit.component.css'
+  styleUrl: './profile-edit.component.css',
+  host: {
+    class: 'card profile-card'
+  }
 })
-export class ProfileEditComponent {
+export class ProfileEditComponent implements OnChanges {
+  @Input({ required: true }) profile!: Profile;
+  @Input() saving = false;
+  @Input() errorMessage: string | null = null;
 
+  @Output() saveProfile = new EventEmitter<ProfileFormValue>();
+  @Output() cancelEdit = new EventEmitter<void>();
+
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly profileForm: FormGroup = this.formBuilder.group({
+    fullName: ['', [Validators.required, Validators.minLength(3)]],
+    email: ['', [Validators.required, Validators.email]],
+    username: ['', [Validators.required, Validators.minLength(4)]],
+    phone: ['', [Validators.required, Validators.minLength(7)]],
+    location: ['', [Validators.required, Validators.minLength(3)]],
+    currentPassword: ['', []],
+    newPassword: ['', [Validators.minLength(6)]],
+    confirmPassword: ['', [Validators.minLength(6)]]
+  });
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['profile'] && this.profile) {
+      this.patchFormWithProfile(this.profile);
+    }
+  }
+
+  get avatarInitials(): string {
+    return this.computeInitials(this.profile?.fullName ?? '');
+  }
+
+  submit(): void {
+    if (this.profileForm.invalid || !this.ensurePasswordsMatch()) {
+      this.profileForm.markAllAsTouched();
+      return;
+    }
+
+    const { fullName, email, username, phone, location } = this.profileForm.value as ProfileFormValue;
+    this.saveProfile.emit({ fullName, email, username, phone, location });
+  }
+
+  resetForm(): void {
+    if (this.profile) {
+      this.patchFormWithProfile(this.profile);
+    }
+    this.profileForm.get('currentPassword')?.reset('');
+    this.profileForm.get('newPassword')?.reset('');
+    this.profileForm.get('confirmPassword')?.reset('');
+    this.cancelEdit.emit();
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const control = this.profileForm.get(fieldName);
+    return !!control && control.invalid && (control.dirty || control.touched);
+  }
+
+  private patchFormWithProfile(profile: Profile): void {
+    this.profileForm.patchValue({
+      fullName: profile.fullName,
+      email: profile.email,
+      username: profile.username,
+      phone: profile.phone,
+      location: profile.location
+    });
+  }
+
+  private computeInitials(fullName: string): string {
+    if (!fullName) {
+      return 'US';
+    }
+
+    const initials = fullName
+      .split(' ')
+      .filter(part => part.trim().length > 0)
+      .slice(0, 2)
+      .map(part => part.trim().charAt(0).toUpperCase())
+      .join('');
+
+    return initials || fullName.charAt(0).toUpperCase();
+  }
+
+  private ensurePasswordsMatch(): boolean {
+    const newPassword = this.profileForm.get('newPassword')?.value?.trim();
+    const confirmPassword = this.profileForm.get('confirmPassword')?.value?.trim();
+
+    if (!newPassword && !confirmPassword) {
+      this.profileForm.get('confirmPassword')?.setErrors(null);
+      return true;
+    }
+
+    if (newPassword !== confirmPassword) {
+      this.profileForm.get('confirmPassword')?.setErrors({ mismatch: true });
+      return false;
+    }
+
+    this.profileForm.get('confirmPassword')?.setErrors(null);
+    return true;
+  }
 }

--- a/src/app/profile/models/profile.entity.ts
+++ b/src/app/profile/models/profile.entity.ts
@@ -1,0 +1,38 @@
+export interface AccountStatus {
+  planName: string;
+  renewalDate: string;
+  supportContact: string;
+  statusLabel: string;
+}
+
+export interface Profile {
+  id: string;
+  fullName: string;
+  role: string;
+  email: string;
+  phone: string;
+  location: string;
+  username: string;
+  accountStatus: AccountStatus;
+  selectedPlanId: string;
+  lastUpdated?: string;
+}
+
+export interface SubscriptionPlan {
+  id: string;
+  name: string;
+  price: string;
+  shortDescription: string;
+  benefits: string[];
+}
+
+export interface ProfileUpdateInput {
+  fullName?: string;
+  email?: string;
+  username?: string;
+  phone?: string;
+  location?: string;
+  accountStatus?: Partial<AccountStatus>;
+  selectedPlanId?: string;
+  lastUpdated?: string;
+}

--- a/src/app/profile/pages/profile/profile.component.css
+++ b/src/app/profile/pages/profile/profile.component.css
@@ -1,15 +1,9 @@
 :host {
   display: block;
-  min-height: 100vh;
-  background: linear-gradient(120deg, #1b1322 0%, #22162b 100%);
-  color: #f7f1ff;
+  min-height: 100%;
+  background-color: #f6f7fb;
+  color: #1f1f1f;
   font-family: 'Roboto', sans-serif;
-}
-
-.profile-layout {
-  display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
-  min-height: 100vh;
 }
 
 .material-symbols-outlined {
@@ -17,220 +11,262 @@
   font-size: 20px;
 }
 
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  background: rgba(33, 18, 38, 0.95);
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 32px 24px;
-  gap: 32px;
-}
-
-.sidebar__brand {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.brand__logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  background: linear-gradient(150deg, #f9a66b 0%, #fecd9f 100%);
-  color: #2a0e1d;
-  font-weight: 700;
-  font-size: 22px;
-  letter-spacing: 1px;
-}
-
-.brand__name {
-  font-size: 14px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 240, 224, 0.72);
-}
-
-.sidebar__nav {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.nav-button {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  width: 100%;
-  padding: 12px 16px;
-  border: 1px solid transparent;
-  border-radius: 14px;
-  background: transparent;
-  color: rgba(255, 245, 235, 0.8);
-  font-size: 15px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-}
-
-.nav-button:hover {
-  background: rgba(255, 215, 180, 0.12);
-  border-color: rgba(255, 215, 180, 0.2);
-  color: #fff7f0;
-}
-
-.nav-button--active {
-  background: rgba(255, 215, 180, 0.18);
-  border-color: rgba(255, 215, 180, 0.45);
-  color: #fff9f3;
-  box-shadow: 0 10px 25px -15px rgba(255, 174, 126, 0.6);
-}
-
-.nav-button__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  background: rgba(255, 215, 180, 0.15);
-  color: #f9be80;
-  font-size: 18px;
-}
-
-.sidebar__footer {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.sidebar__hint {
-  font-size: 12px;
-  color: rgba(255, 245, 235, 0.55);
+.profile-layout {
+  padding: 2.5rem 2rem 3rem;
 }
 
 .workspace {
-  padding: 48px 56px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 2rem;
 }
 
 .workspace__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 24px;
-  padding: 24px 32px;
+  gap: 1.5rem;
+  padding: 1.75rem 2rem;
+  border-radius: 1.5rem;
+  background: #ffffff;
+  border: 1px solid rgba(31, 31, 31, 0.06);
+  box-shadow: 0 18px 36px rgba(46, 27, 66, 0.08);
 }
 
 .header__title {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 1.25rem;
 }
 
 .header__icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  background: rgba(255, 215, 180, 0.18);
-  color: #f7b16e;
+  width: 48px;
+  height: 48px;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #6b0f0f, #c81d33);
+  color: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 26px;
 }
 
 .header__title h1 {
-  margin: 0 0 4px;
-  font-size: 26px;
-  font-weight: 600;
+  margin: 0;
+  font-size: 1.9rem;
+  font-weight: 700;
 }
 
 .header__title p {
-  margin: 0;
-  color: rgba(255, 245, 235, 0.72);
+  margin: 0.25rem 0 0;
+  color: #565b65;
+  font-size: 0.95rem;
 }
 
 .header__status-chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
   border-radius: 999px;
-  border: 1px solid rgba(92, 233, 188, 0.4);
-  background: rgba(92, 233, 188, 0.12);
-  color: #9ff2d1;
+  border: 1px solid rgba(52, 199, 142, 0.35);
+  background: rgba(52, 199, 142, 0.12);
+  color: #21825c;
   font-weight: 600;
 }
 
 .workspace__grid {
   display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 24px;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.workspace__error {
+  margin: 0;
+  color: #c81d33;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.workspace__loading,
+.workspace__empty {
+  margin-top: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1.25rem;
+  background: #ffffff;
+  border: 1px solid rgba(31, 31, 31, 0.06);
+  box-shadow: 0 12px 24px rgba(46, 27, 66, 0.06);
+  color: #4a4f59;
+}
+
+.workspace__loading .material-symbols-outlined,
+.workspace__empty .material-symbols-outlined {
+  font-size: 24px;
+  color: #c81d33;
 }
 
 .card {
-  background: rgba(30, 17, 33, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 28px;
-  padding: 32px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 25px 45px -30px rgba(12, 7, 16, 0.9);
+  background: #ffffff;
+  border: 1px solid rgba(31, 31, 31, 0.06);
+  border-radius: 1.75rem;
+  padding: 2rem;
+  box-shadow: 0 18px 32px rgba(46, 27, 66, 0.08);
 }
 
 .card__header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
-  margin-bottom: 24px;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .card__header h2 {
   margin: 0;
-  font-size: 22px;
+  font-size: 1.4rem;
   font-weight: 600;
 }
 
 .card__header p {
-  margin: 6px 0 0;
-  color: rgba(255, 245, 235, 0.72);
-  font-size: 14px;
+  margin: 0.35rem 0 0;
+  color: #5c6270;
+  font-size: 0.95rem;
 }
 
 .profile-card {
   grid-column: span 8;
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
-  gap: 24px;
+  gap: 1.5rem;
+}
+
+.plans-card {
+  grid-column: span 8;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.plans-card__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.plan {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(31, 31, 31, 0.08);
+  background: #ffffff;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.plan:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 28px rgba(46, 27, 66, 0.12);
+}
+
+.plan--selected {
+  border-color: rgba(200, 29, 51, 0.45);
+  box-shadow: 0 20px 32px rgba(200, 29, 51, 0.18);
+}
+
+.plan__header {
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.plan__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.plan__price {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #6b0f0f;
+}
+
+.plan__price small {
+  font-size: 0.75rem;
+  color: #5c6270;
+  margin-left: 0.25rem;
+}
+
+.plan__description {
+  margin: 0;
+  color: #5c6270;
+  font-size: 0.95rem;
+}
+
+.plan__benefits {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #3a3f48;
+}
+
+.plan__benefits li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.plan__benefits .material-symbols-outlined {
+  font-size: 1.1rem;
+  color: #21825c;
+}
+
+.plan__cta {
+  margin-top: auto;
+  font-weight: 600;
+  color: #6b0f0f;
+}
+
+.plan.plan--selected .plan__cta {
+  color: #c81d33;
+}
+
+.plan small {
+  font-size: 0.75rem;
+  color: #6f7684;
 }
 
 .profile-card__user {
-  background: rgba(46, 28, 53, 0.7);
-  border-radius: 20px;
-  padding: 28px 24px;
+  background: linear-gradient(160deg, #fce7ef, #f7d7c9);
+  border-radius: 1.5rem;
+  padding: 2rem 1.75rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
   text-align: center;
+  color: #4a1031;
 }
 
 .avatar {
-  width: 86px;
-  height: 86px;
-  border-radius: 24px;
-  background: linear-gradient(160deg, #fbd3a3 0%, #f7a26c 100%);
-  color: #2a0e1d;
-  font-size: 32px;
+  width: 88px;
+  height: 88px;
+  border-radius: 1.75rem;
+  background: linear-gradient(135deg, #6b0f0f, #c81d33);
+  color: #ffffff;
+  font-size: 2rem;
   font-weight: 700;
   display: flex;
   align-items: center;
@@ -239,7 +275,7 @@
 
 .profile-card__role {
   margin: 0;
-  color: rgba(255, 245, 235, 0.7);
+  color: rgba(74, 16, 49, 0.75);
 }
 
 .profile-card__details {
@@ -247,75 +283,75 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 1rem;
 }
 
 .profile-card__details div {
   display: grid;
   grid-template-columns: 32px minmax(0, 1fr);
-  gap: 10px;
+  gap: 0.65rem;
   align-items: center;
   text-align: left;
-  color: rgba(255, 245, 235, 0.8);
+  color: rgba(74, 16, 49, 0.9);
 }
 
 .profile-card__details dt {
   margin: 0;
-  font-size: 20px;
-  color: #f8bd7e;
+  font-size: 1.4rem;
+  color: #6b0f0f;
 }
 
 .profile-card__details dd {
   margin: 0;
-  font-size: 14px;
+  font-size: 0.95rem;
   line-height: 1.4;
 }
 
 .profile-card__form {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px 24px;
+  gap: 1.25rem 1.5rem;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0.5rem;
 }
 
 .form-field label {
-  font-weight: 500;
-  color: rgba(255, 245, 235, 0.82);
+  font-weight: 600;
+  color: #3a3f48;
 }
 
 .form-field input {
-  padding: 12px 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(20, 9, 24, 0.8);
-  color: #fff7f0;
-  font-size: 15px;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(31, 31, 31, 0.12);
+  background: #ffffff;
+  color: #1f1f1f;
+  font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .form-field input::placeholder {
-  color: rgba(255, 245, 235, 0.45);
+  color: #9aa0ad;
 }
 
 .form-field input:focus {
   outline: none;
-  border-color: rgba(249, 182, 116, 0.8);
-  box-shadow: 0 0 0 3px rgba(249, 182, 116, 0.18);
+  border-color: #c81d33;
+  box-shadow: 0 0 0 3px rgba(200, 29, 51, 0.15);
 }
 
 .form-field--error input {
-  border-color: rgba(255, 126, 148, 0.9);
-  box-shadow: 0 0 0 3px rgba(255, 126, 148, 0.12);
+  border-color: rgba(200, 29, 51, 0.7);
+  box-shadow: 0 0 0 3px rgba(200, 29, 51, 0.12);
 }
 
 .field-error {
-  font-size: 12px;
-  color: #ff9ba8;
+  font-size: 0.8rem;
+  color: #c81d33;
 }
 
 .password-group {
@@ -326,100 +362,91 @@
   grid-column: span 2;
   display: flex;
   justify-content: flex-end;
-  gap: 16px;
-  margin-top: 12px;
+  gap: 1rem;
+  margin-top: 0.5rem;
 }
 
 .primary-button,
 .secondary-button,
 .ghost-button {
   font-weight: 600;
-  border-radius: 14px;
-  padding: 12px 24px;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
   border: 1px solid transparent;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .primary-button {
-  background: linear-gradient(150deg, #f7a26c 0%, #fbd3a3 100%);
-  color: #2a0e1d;
-  box-shadow: 0 12px 24px -10px rgba(247, 162, 108, 0.65);
+  background: linear-gradient(135deg, #6b0f0f, #c81d33);
+  color: #ffffff;
+  box-shadow: 0 12px 22px rgba(200, 29, 51, 0.25);
 }
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 30px -12px rgba(247, 162, 108, 0.75);
+  box-shadow: 0 16px 28px rgba(200, 29, 51, 0.3);
+}
+
+.primary-button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
 }
 
 .secondary-button {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.16);
-  color: #fff7f0;
+  background: #ffffff;
+  border-color: rgba(31, 31, 31, 0.12);
+  color: #3a3f48;
 }
 
 .secondary-button:hover {
-  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(200, 29, 51, 0.35);
+  color: #6b0f0f;
 }
 
 .ghost-button {
   background: transparent;
-  border-color: rgba(255, 255, 255, 0.16);
-  color: rgba(255, 245, 235, 0.85);
+  border-color: rgba(31, 31, 31, 0.12);
+  color: #3a3f48;
 }
 
 .ghost-button:hover {
-  border-color: rgba(249, 182, 116, 0.5);
-  color: #fff7f0;
+  border-color: rgba(200, 29, 51, 0.35);
+  color: #6b0f0f;
 }
 
 .account-card {
   grid-column: span 4;
 }
 
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 12px;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.status-chip--active {
-  background: rgba(132, 255, 206, 0.12);
-  border: 1px solid rgba(132, 255, 206, 0.35);
-  color: #9ff2d1;
-}
-
 .account-card__plan {
-  margin: 0 0 10px;
-  font-size: 20px;
-  font-weight: 600;
+  margin: 0 0 0.75rem;
+  font-size: 1.5rem;
+  font-weight: 700;
 }
 
 .account-card__subtitle {
-  margin: 0 0 24px;
-  color: rgba(255, 245, 235, 0.72);
-  font-size: 14px;
+  margin: 0 0 1.25rem;
+  color: #5c6270;
+  font-size: 0.95rem;
 }
 
 .account-card__actions {
   display: flex;
-  gap: 12px;
-  margin-bottom: 18px;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
 }
 
 .account-card__support {
   margin: 0;
-  font-size: 13px;
-  color: rgba(255, 245, 235, 0.7);
+  color: #5c6270;
+  font-size: 0.95rem;
 }
 
 .account-card__support a {
-  color: #f9be80;
+  color: #c81d33;
   text-decoration: none;
 }
 
@@ -427,176 +454,53 @@
   text-decoration: underline;
 }
 
-.plans-card {
-  grid-column: span 8;
-}
-
-.plans-card__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 20px;
-}
-
-.plan {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 24px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(36, 20, 41, 0.85);
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.plan:hover {
-  border-color: rgba(249, 182, 116, 0.6);
-  transform: translateY(-4px);
-  box-shadow: 0 20px 35px -25px rgba(249, 182, 116, 0.8);
-}
-
-.plan--selected {
-  border-color: rgba(249, 182, 116, 0.85);
-  box-shadow: 0 24px 40px -22px rgba(249, 182, 116, 0.8);
-  background: linear-gradient(150deg, rgba(249, 182, 116, 0.15) 0%, rgba(249, 182, 116, 0.05) 100%);
-}
-
-.plan__header {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-}
-
-.plan__price {
-  font-size: 22px;
-  font-weight: 600;
-  color: #f9be80;
-}
-
-.plan__price small {
-  font-size: 12px;
-  color: rgba(255, 245, 235, 0.6);
-}
-
-.plan__description {
-  margin: 0;
-  font-size: 13px;
-  color: rgba(255, 245, 235, 0.75);
-}
-
-.plan__benefits {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.plan__benefits li {
-  display: flex;
+.status-chip {
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-size: 13px;
-  color: rgba(255, 245, 235, 0.85);
-}
-
-.plan__benefits .material-symbols-outlined {
-  color: #9ff2d1;
-  font-size: 18px;
-}
-
-.plan__cta {
-  margin-top: auto;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
   font-weight: 600;
-  color: #f9be80;
+}
+
+.status-chip--active {
+  background: rgba(107, 15, 15, 0.12);
+  color: #6b0f0f;
 }
 
 .benefits-card {
   grid-column: span 4;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
 .benefits-card__list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1rem;
+  color: #3a3f48;
 }
 
 .benefits-card__list li {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  color: rgba(255, 245, 235, 0.78);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(107, 15, 15, 0.04);
 }
 
 .benefits-card__list .material-symbols-outlined {
-  font-size: 18px;
-  color: #f7b16e;
-  margin-top: 2px;
+  font-size: 1.1rem;
+  color: #c81d33;
 }
 
-@media (max-width: 1260px) {
-  .profile-layout {
-    grid-template-columns: 230px minmax(0, 1fr);
-  }
-
-  .profile-card {
-    grid-column: span 12;
-  }
-
-  .account-card {
-    grid-column: span 6;
-  }
-
-  .plans-card {
-    grid-column: span 12;
-  }
-
-  .benefits-card {
-    grid-column: span 6;
-  }
-}
-
-@media (max-width: 992px) {
-  .profile-layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .sidebar {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 20px 28px;
-    border-right: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  }
-
-  .sidebar__nav {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .nav-button {
-    flex: 1 1 120px;
-  }
-
-  .workspace {
-    padding: 32px 24px 48px;
-  }
-
-  .workspace__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
+@media (max-width: 1200px) {
   .profile-card {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -606,45 +510,31 @@
   }
 
   .form-actions {
-    grid-column: span 1;
+    grid-column: auto;
     justify-content: stretch;
   }
 
   .form-actions button {
-    flex: 1;
-  }
-
-  .account-card,
-  .benefits-card {
-    grid-column: span 12;
+    width: 100%;
   }
 }
 
-@media (max-width: 680px) {
-  .workspace {
-    padding: 24px 16px 40px;
+@media (max-width: 768px) {
+  .profile-layout {
+    padding: 2rem 1.5rem 2.5rem;
+  }
+
+  .workspace__header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .workspace__grid {
-    gap: 18px;
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .card {
-    padding: 24px;
-  }
-
-  .sidebar {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 16px;
-  }
-
-  .sidebar__nav {
-    width: 100%;
-    gap: 8px;
-  }
-
-  .nav-button {
-    width: 100%;
+  .account-card,
+  .profile-card {
+    grid-column: auto;
   }
 }

--- a/src/app/profile/pages/profile/profile.component.html
+++ b/src/app/profile/pages/profile/profile.component.html
@@ -1,182 +1,91 @@
 <div class="profile-layout">
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <span class="brand__logo">WI</span>
-      <span class="brand__name">WineInventory</span>
-    </div>
-    <nav class="sidebar__nav">
-      <button
-        *ngFor="let link of sidebarLinks"
-        type="button"
-        class="nav-button"
-        [class.nav-button--active]="link.active"
-      >
-        <span class="nav-button__icon material-symbols-outlined">{{ link.icon }}</span>
-        <span class="nav-button__label">{{ link.label }}</span>
-      </button>
-    </nav>
-    <div class="sidebar__footer">
-      <p class="sidebar__hint">Actualizado hace 5 min</p>
-      <button type="button" class="secondary-button">Cerrar sesión</button>
-    </div>
-  </aside>
-
   <section class="workspace">
     <header class="workspace__header">
       <div class="header__title">
         <div class="header__icon material-symbols-outlined">badge</div>
         <div>
-          <h1>Perfil</h1>
-          <p>Gestiona tu información personal, credenciales y plan de suscripción.</p>
+          <h1>{{ isSettingsView() ? 'Ajustes' : 'Perfil' }}</h1>
+          <p *ngIf="!isSettingsView()">Gestiona tu información personal, credenciales y plan de suscripción.</p>
+          <p *ngIf="isSettingsView()">Actualiza tus datos personales y preferencias de acceso.</p>
         </div>
       </div>
-      <div class="header__status-chip">
+
+      <div class="header__status-chip" *ngIf="accountStatus() as status">
         <span class="material-symbols-outlined">verified</span>
-        Cuenta verificada
+        {{ status.statusLabel }}
       </div>
     </header>
 
-    <div class="workspace__grid">
-      <article class="card profile-card">
-        <div class="profile-card__user">
-          <div class="avatar">JP</div>
-          <h2>{{ userProfile.fullName }}</h2>
-          <p class="profile-card__role">{{ userProfile.role }}</p>
-          <dl class="profile-card__details">
-            <div>
-              <dt class="material-symbols-outlined">mail</dt>
-              <dd>{{ userProfile.email }}</dd>
+    <p class="workspace__error" *ngIf="loadError() as errorMessage">{{ errorMessage }}</p>
+
+    <ng-container *ngIf="!isLoading(); else loading">
+      <ng-container *ngIf="profile() as currentProfile; else emptyProfile">
+        <div class="workspace__grid">
+          <app-profile-edit
+            [profile]="currentProfile"
+            [saving]="isSaving()"
+            [errorMessage]="updateError()"
+            (saveProfile)="handleProfileSave($event)"
+            (cancelEdit)="handleCancelEdit()"
+          ></app-profile-edit>
+
+          <article class="card account-card" *ngIf="accountStatus() as status">
+            <header class="card__header">
+              <h2>Tipo de cuenta</h2>
+              <span class="status-chip status-chip--active">
+                <span class="material-symbols-outlined">workspace_premium</span>
+                {{ status.statusLabel }}
+              </span>
+            </header>
+            <div class="account-card__body">
+              <p class="account-card__plan">{{ status.planName }}</p>
+              <p class="account-card__subtitle">
+                Tu plan se renovará automáticamente el {{ status.renewalDate | date: 'dd MMMM yyyy' }}.
+              </p>
+              <div class="account-card__actions">
+                <button
+                  type="button"
+                  class="primary-button"
+                  (click)="selectedPlanId() && handlePlanSelected(selectedPlanId()!)"
+                  [disabled]="isSaving() || !selectedPlanId()"
+                >
+                  Mantener plan actual
+                </button>
+                <button type="button" class="ghost-button" [disabled]="isSaving()">
+                  Contactar soporte
+                </button>
+              </div>
+              <p class="account-card__support">
+                ¿Necesitas ayuda? Escríbenos a
+                <a [href]="'mailto:' + status.supportContact">{{ status.supportContact }}</a>.
+              </p>
             </div>
-            <div>
-              <dt class="material-symbols-outlined">call</dt>
-              <dd>{{ userProfile.phone }}</dd>
-            </div>
-            <div>
-              <dt class="material-symbols-outlined">location_on</dt>
-              <dd>{{ userProfile.location }}</dd>
-            </div>
-          </dl>
+          </article>
+
+          <app-plan-details
+            [plans]="plans()"
+            [selectedPlanId]="selectedPlanId()"
+            [disabled]="isSaving()"
+            (planSelected)="handlePlanSelected($event)"
+          ></app-plan-details>
+
+          <app-plan-benefits [benefits]="premiumBenefits()"></app-plan-benefits>
         </div>
-
-        <form class="profile-card__form" [formGroup]="profileForm" (ngSubmit)="submitProfileForm()">
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('fullName')">
-            <label for="fullName">Nombre</label>
-            <input id="fullName" type="text" formControlName="fullName" placeholder="Ingresa tu nombre completo" />
-            <span class="field-error" *ngIf="isFieldInvalid('fullName')">
-              Debe contener al menos 3 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('email')">
-            <label for="email">Correo electrónico</label>
-            <input id="email" type="email" formControlName="email" placeholder="correo@empresa.com" />
-            <span class="field-error" *ngIf="isFieldInvalid('email')">
-              Ingresa un correo electrónico válido.
-            </span>
-          </div>
-
-          <div class="form-field" [class.form-field--error]="isFieldInvalid('username')">
-            <label for="username">Nombre de usuario</label>
-            <input id="username" type="text" formControlName="username" placeholder="usuario" />
-            <span class="field-error" *ngIf="isFieldInvalid('username')">
-              Debe contener al menos 4 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('currentPassword')">
-            <label for="currentPassword">Contraseña actual</label>
-            <input id="currentPassword" type="password" formControlName="currentPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('currentPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('newPassword')">
-            <label for="newPassword">Nueva contraseña</label>
-            <input id="newPassword" type="password" formControlName="newPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('newPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-field password-group" [class.form-field--error]="isFieldInvalid('confirmPassword')">
-            <label for="confirmPassword">Confirmar contraseña</label>
-            <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="••••••" />
-            <span class="field-error" *ngIf="isFieldInvalid('confirmPassword')">
-              La contraseña debe tener al menos 6 caracteres.
-            </span>
-          </div>
-
-          <div class="form-actions">
-            <button type="button" class="secondary-button">Cancelar</button>
-            <button type="submit" class="primary-button">Guardar cambios</button>
-          </div>
-        </form>
-      </article>
-
-      <article class="card account-card">
-        <header class="card__header">
-          <h2>Tipo de cuenta</h2>
-          <span class="status-chip status-chip--active">
-            <span class="material-symbols-outlined">workspace_premium</span>
-            {{ accountStatus.statusLabel }}
-          </span>
-        </header>
-        <div class="account-card__body">
-          <p class="account-card__plan">{{ accountStatus.planName }}</p>
-          <p class="account-card__subtitle">Tu plan se renovará automáticamente el {{ accountStatus.renewalDate }}.</p>
-          <div class="account-card__actions">
-            <button type="button" class="primary-button">Actualizar plan</button>
-            <button type="button" class="ghost-button">Contactar soporte</button>
-          </div>
-          <p class="account-card__support">
-            ¿Necesitas ayuda? Escríbenos a
-            <a href="mailto:{{ accountStatus.supportContact }}">{{ accountStatus.supportContact }}</a>.
-          </p>
-        </div>
-      </article>
-
-      <article class="card plans-card">
-        <header class="card__header">
-          <h2>Planes</h2>
-          <p>Selecciona el plan que mejor se adapte al crecimiento de tu bodega.</p>
-        </header>
-        <div class="plans-card__grid">
-          <button
-            *ngFor="let plan of plans"
-            type="button"
-            class="plan"
-            [class.plan--selected]="selectedPlanId() === plan.id"
-            (click)="selectPlan(plan.id)"
-          >
-            <div class="plan__header">
-              <h3>{{ plan.name }}</h3>
-              <span class="plan__price">{{ plan.price }}<small>/mes</small></span>
-            </div>
-            <p class="plan__description">{{ plan.shortDescription }}</p>
-            <ul class="plan__benefits">
-              <li *ngFor="let benefit of plan.benefits">
-                <span class="material-symbols-outlined">check_circle</span>
-                {{ benefit }}
-              </li>
-            </ul>
-            <span class="plan__cta">Elegir este plan</span>
-          </button>
-        </div>
-      </article>
-
-      <article class="card benefits-card">
-        <header class="card__header">
-          <h2>Beneficios del Plan Premium</h2>
-          <p>Aprovecha al máximo la versión más completa del sistema.</p>
-        </header>
-        <ul class="benefits-card__list">
-          <li *ngFor="let benefit of premiumBenefits">
-            <span class="material-symbols-outlined">star</span>
-            {{ benefit }}
-          </li>
-        </ul>
-      </article>
-    </div>
+      </ng-container>
+    </ng-container>
   </section>
 </div>
+
+<ng-template #loading>
+  <div class="workspace__loading">
+    <span class="material-symbols-outlined">hourglass_empty</span>
+    Cargando información del perfil…
+  </div>
+</ng-template>
+
+<ng-template #emptyProfile>
+  <div class="workspace__empty">
+    <span class="material-symbols-outlined">person_off</span>
+    No encontramos información del perfil para mostrar.
+  </div>
+</ng-template>

--- a/src/app/profile/services/profile.service.ts
+++ b/src/app/profile/services/profile.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, forkJoin, throwError } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+import { environment } from '../../../environments/environment';
+import { AccountStatus, Profile, ProfileUpdateInput, SubscriptionPlan } from '../models/profile.entity';
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private readonly http = inject(HttpClient);
+
+  private readonly profileEndpoint = `${environment.apiUrl}/profiles`;
+  private readonly plansEndpoint = `${environment.apiUrl}/subscriptionPlans`;
+  private readonly benefitsEndpoint = `${environment.apiUrl}/premiumBenefits`;
+  private readonly profileId = 'current';
+
+  private readonly profileSubject = new BehaviorSubject<Profile | null>(null);
+  private readonly plansSubject = new BehaviorSubject<SubscriptionPlan[]>([]);
+  private readonly benefitsSubject = new BehaviorSubject<string[]>([]);
+
+  getProfile(): Observable<Profile | null> {
+    return this.profileSubject.asObservable();
+  }
+
+  getPlans(): Observable<SubscriptionPlan[]> {
+    return this.plansSubject.asObservable();
+  }
+
+  getPremiumBenefits(): Observable<string[]> {
+    return this.benefitsSubject.asObservable();
+  }
+
+  refreshProfile(): Observable<Profile> {
+    return this.http.get<Profile>(`${this.profileEndpoint}/${this.profileId}`).pipe(
+      tap({
+        next: profile => this.profileSubject.next(profile),
+        error: error => console.error('No se pudo cargar el perfil.', error)
+      })
+    );
+  }
+
+  refreshPlans(): Observable<SubscriptionPlan[]> {
+    return this.http.get<SubscriptionPlan[]>(this.plansEndpoint).pipe(
+      tap({
+        next: plans => this.plansSubject.next(plans),
+        error: error => console.error('No se pudieron cargar los planes.', error)
+      })
+    );
+  }
+
+  refreshBenefits(): Observable<string[]> {
+    return this.http.get<string[]>(this.benefitsEndpoint).pipe(
+      tap({
+        next: benefits => this.benefitsSubject.next(benefits),
+        error: error => console.error('No se pudieron cargar los beneficios del plan.', error)
+      })
+    );
+  }
+
+  refreshAll(): Observable<{ profile: Profile; plans: SubscriptionPlan[]; benefits: string[] }> {
+    return forkJoin({
+      profile: this.refreshProfile(),
+      plans: this.refreshPlans(),
+      benefits: this.refreshBenefits()
+    });
+  }
+
+  updateProfile(changes: ProfileUpdateInput): Observable<Profile> {
+    if (!changes || typeof changes !== 'object') {
+      return throwError(() => new Error('Los cambios proporcionados no son válidos.'));
+    }
+
+    return this.http.patch<Profile>(`${this.profileEndpoint}/${this.profileId}`, changes).pipe(
+      tap({
+        next: profile => this.profileSubject.next(profile),
+        error: error => console.error('No se pudo actualizar el perfil.', error)
+      })
+    );
+  }
+
+  getProfileSnapshot(): Profile | null {
+    return this.profileSubject.getValue();
+  }
+
+  getPlansSnapshot(): SubscriptionPlan[] {
+    return this.plansSubject.getValue();
+  }
+
+  getBenefitsSnapshot(): string[] {
+    return this.benefitsSubject.getValue();
+  }
+
+  buildAccountStatusForPlan(planId: string): AccountStatus | null {
+    const profile = this.profileSubject.getValue();
+    const plans = this.plansSubject.getValue();
+    if (!profile || plans.length === 0) {
+      return null;
+    }
+
+    const selectedPlan = plans.find(plan => plan.id === planId);
+    if (!selectedPlan) {
+      return profile.accountStatus;
+    }
+
+    return {
+      ...profile.accountStatus,
+      planName: selectedPlan.name,
+      statusLabel: profile.accountStatus.statusLabel || 'Activo'
+    };
+  }
+}

--- a/src/app/shared/presentation/components/side-navbar/side-navbar.component.ts
+++ b/src/app/shared/presentation/components/side-navbar/side-navbar.component.ts
@@ -34,7 +34,7 @@ export class SideNavbarComponent implements OnInit {
     { icon: 'shopping_cart', label: 'side-navbar.options.order', route: ['/dashboard', 'sales'] },
     { icon: 'assessment', label: 'side-navbar.options.report', route: ['/dashboard', 'reports'] },
     { icon: 'notifications', label: 'side-navbar.options.alert', route: ['/dashboard', 'alerts'] },
-    { icon: 'settings', label: 'side-navbar.options.configuration', route: ['/dashboard', 'settings'] }
+    { icon: 'settings', label: 'side-navbar.options.configuration', route: ['/dashboard', 'profile', 'settings'] }
   ];
 
   unreadAlerts = 3;
@@ -59,7 +59,7 @@ export class SideNavbarComponent implements OnInit {
   onNavItemClick(item: NavItem) {
     this.navItems.forEach(i => i.isActive = false);
     item.isActive = true;
-    this.router.navigate([item.route[0]]);
+    this.router.navigate(item.route);
   }
   logout() {
 


### PR DESCRIPTION
## Summary
- nest the profile views under the dashboard route and redirect legacy profile URLs to preserve navigation
- streamline the profile page so it renders within the dashboard content area with refreshed styling and layout helpers
- point the sidebar configuration link to the new dashboard profile settings path and align supporting styles with the lighter dashboard theme

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/... returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_b_68e18d84a54483309f329ca166727835