### PR TITLE
Revamp profile views with avatar support

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -201,13 +201,14 @@
   ],
   "profiles": [
     {
-      "id": "current",
+      "id": "us-001",
       "fullName": "Juan Pérez",
       "role": "Administrador General",
       "email": "juanperez@email.com",
       "phone": "+52 55 1234 5678",
       "location": "Ciudad de México, MX",
       "username": "jperez",
+      "avatarUrl": "https://images.unsplash.com/photo-1544723795-3fb6469f5b39",
       "accountStatus": {
         "planName": "Plan Premium",
         "renewalDate": "2025-03-15T00:00:00.000Z",

--- a/src/app/profile/components/profile-edit/profile-edit.component.html
+++ b/src/app/profile/components/profile-edit/profile-edit.component.html
@@ -1,5 +1,17 @@
 <div class="profile-card__user" *ngIf="profile as profileData">
-  <div class="avatar">{{ avatarInitials }}</div>
+  <div class="profile-card__avatar">
+    <ng-container *ngIf="shouldShowAvatarImage; else initialsAvatar">
+      <img
+        class="avatar-image"
+        [src]="profileData.avatarUrl"
+        [alt]="'Foto de ' + profileData.fullName"
+        (error)="handleAvatarError()"
+      />
+    </ng-container>
+    <ng-template #initialsAvatar>
+      <div class="avatar">{{ avatarInitials }}</div>
+    </ng-template>
+  </div>
   <h2>{{ profileData.fullName }}</h2>
   <p class="profile-card__role">{{ profileData.role }}</p>
 

--- a/src/app/profile/components/profile-edit/profile-edit.component.ts
+++ b/src/app/profile/components/profile-edit/profile-edit.component.ts
@@ -31,6 +31,7 @@ export class ProfileEditComponent implements OnChanges {
   @Output() cancelEdit = new EventEmitter<void>();
 
   private readonly formBuilder = inject(FormBuilder);
+  private avatarHasError = false;
 
   readonly profileForm: FormGroup = this.formBuilder.group({
     fullName: ['', [Validators.required, Validators.minLength(3)]],
@@ -45,6 +46,7 @@ export class ProfileEditComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['profile'] && this.profile) {
+      this.avatarHasError = false;
       this.patchFormWithProfile(this.profile);
     }
   }
@@ -86,6 +88,14 @@ export class ProfileEditComponent implements OnChanges {
       phone: profile.phone,
       location: profile.location
     });
+  }
+
+  handleAvatarError(): void {
+    this.avatarHasError = true;
+  }
+
+  get shouldShowAvatarImage(): boolean {
+    return !!this.profile?.avatarUrl && !this.avatarHasError;
   }
 
   private computeInitials(fullName: string): string {

--- a/src/app/profile/models/profile.entity.ts
+++ b/src/app/profile/models/profile.entity.ts
@@ -13,6 +13,7 @@ export interface Profile {
   phone: string;
   location: string;
   username: string;
+  avatarUrl?: string;
   accountStatus: AccountStatus;
   selectedPlanId: string;
   lastUpdated?: string;
@@ -32,6 +33,7 @@ export interface ProfileUpdateInput {
   username?: string;
   phone?: string;
   location?: string;
+  avatarUrl?: string;
   accountStatus?: Partial<AccountStatus>;
   selectedPlanId?: string;
   lastUpdated?: string;

--- a/src/app/profile/pages/profile/profile.component.css
+++ b/src/app/profile/pages/profile/profile.component.css
@@ -162,14 +162,190 @@
 }
 
 .profile-card {
-  grid-column: span 8;
+  width: 100%;
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 2rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
+.profile-overview {
+  grid-column: span 7;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  background: linear-gradient(160deg, #ffffff, #ffe0e9);
+  border: 1px solid rgba(200, 29, 51, 0.2);
+  box-shadow: 0 26px 48px rgba(200, 29, 51, 0.16);
+}
+
+.profile-overview__header {
+  display: flex;
+  align-items: center;
   gap: 1.5rem;
 }
 
+.profile-overview__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 2rem;
+  overflow: hidden;
+  background: rgba(200, 29, 51, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-overview__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-overview__initials {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #6b0f0f;
+}
+
+.profile-overview__id {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(107, 15, 15, 0.7);
+  margin-bottom: 0.5rem;
+}
+
+.profile-overview__header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.profile-overview__header p {
+  margin: 0.25rem 0 0;
+  color: #5c6270;
+}
+
+.profile-overview__details {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem 1.5rem;
+}
+
+.profile-overview__details div {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #4a1031;
+}
+
+.profile-overview__details dt {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #c81d33;
+}
+
+.profile-overview__details dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.profile-overview__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.profile-overview__actions .primary-button {
+  min-width: 180px;
+}
+
+.summary-grid__plans {
+  grid-column: span 7;
+}
+
+.summary-grid__benefits {
+  grid-column: span 5;
+}
+
+.settings-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-view__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, #201223, #3a1831);
+  color: #f5f0f2;
+  box-shadow: 0 20px 40px rgba(32, 18, 35, 0.25);
+}
+
+.settings-view__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.settings-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(245, 240, 242, 0.78);
+}
+
+.settings-view__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #f5f0f2;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-view__back:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.settings-view__panel {
+  padding: 0.5rem;
+}
+
+.settings-view__panel .profile-card {
+  background: linear-gradient(135deg, #ffffff, #fbe0e9);
+  border: 1px solid rgba(200, 29, 51, 0.18);
+  box-shadow: 0 28px 52px rgba(200, 29, 51, 0.15);
+  padding: 2.75rem 2.5rem;
+}
+
+.settings-view__panel .profile-card__user {
+  background: rgba(107, 15, 15, 0.08);
+  border-radius: 1.75rem;
+  padding: 2rem 1.5rem;
+}
+
+.settings-view__panel .profile-card__form {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: inset 0 0 0 1px rgba(200, 29, 51, 0.08);
+}
+
 .plans-card {
-  grid-column: span 8;
+  grid-column: span 7;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -285,17 +461,38 @@
   color: #4a1031;
 }
 
-.avatar {
-  width: 88px;
-  height: 88px;
+.profile-card__avatar {
+  width: 96px;
+  height: 96px;
   border-radius: 1.75rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: linear-gradient(135deg, #6b0f0f, #c81d33);
+  box-shadow: 0 16px 32px rgba(200, 29, 51, 0.2);
+}
+
+.profile-card__avatar .avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
   color: #ffffff;
   font-size: 2rem;
   font-weight: 700;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.settings-view__panel .profile-card__avatar {
+  background: linear-gradient(135deg, rgba(107, 15, 15, 0.45), rgba(200, 29, 51, 0.65));
 }
 
 .profile-card__role {
@@ -442,7 +639,7 @@
 }
 
 .account-card {
-  grid-column: span 4;
+  grid-column: span 5;
 }
 
 .account-card__plan {
@@ -495,7 +692,7 @@
 }
 
 .benefits-card {
-  grid-column: span 4;
+  grid-column: span 5;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -542,6 +739,22 @@
   .form-actions button {
     width: 100%;
   }
+
+  .summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .profile-overview,
+  .summary-grid__plans,
+  .account-card,
+  .benefits-card {
+    grid-column: span 2;
+  }
+
+  .settings-view__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 768px) {
@@ -554,12 +767,26 @@
     align-items: flex-start;
   }
 
-  .workspace__grid {
+  .summary-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .profile-overview,
+  .summary-grid__plans,
   .account-card,
-  .profile-card {
+  .benefits-card {
     grid-column: auto;
+  }
+
+  .profile-overview__details {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-view__panel .profile-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .settings-view__panel .profile-card__form {
+    padding: 1.5rem;
   }
 }

--- a/src/app/profile/pages/profile/profile.component.html
+++ b/src/app/profile/pages/profile/profile.component.html
@@ -1,5 +1,5 @@
 <div class="profile-layout">
-  <section class="workspace">
+  <section class="workspace" [class.workspace--settings]="isSettingsView()">
     <header class="workspace__header">
       <div class="header__title">
         <div class="header__icon material-symbols-outlined">badge</div>
@@ -20,57 +20,122 @@
 
     <ng-container *ngIf="!isLoading(); else loading">
       <ng-container *ngIf="profile() as currentProfile; else emptyProfile">
-        <div class="workspace__grid">
-          <app-profile-edit
-            [profile]="currentProfile"
-            [saving]="isSaving()"
-            [errorMessage]="updateError()"
-            (saveProfile)="handleProfileSave($event)"
-            (cancelEdit)="handleCancelEdit()"
-          ></app-profile-edit>
-
-          <article class="card account-card" *ngIf="accountStatus() as status">
-            <header class="card__header">
-              <h2>Tipo de cuenta</h2>
-              <span class="status-chip status-chip--active">
-                <span class="material-symbols-outlined">workspace_premium</span>
-                {{ status.statusLabel }}
-              </span>
-            </header>
-            <div class="account-card__body">
-              <p class="account-card__plan">{{ status.planName }}</p>
-              <p class="account-card__subtitle">
-                Tu plan se renovará automáticamente el {{ status.renewalDate | date: 'dd MMMM yyyy' }}.
-              </p>
-              <div class="account-card__actions">
-                <button
-                  type="button"
-                  class="primary-button"
-                  (click)="selectedPlanId() && handlePlanSelected(selectedPlanId()!)"
-                  [disabled]="isSaving() || !selectedPlanId()"
-                >
-                  Mantener plan actual
-                </button>
-                <button type="button" class="ghost-button" [disabled]="isSaving()">
-                  Contactar soporte
+        <ng-container *ngIf="isSettingsView(); else summaryView">
+          <div class="settings-view">
+            <div class="settings-view__header">
+              <button type="button" class="ghost-button settings-view__back" (click)="goToProfile()">
+                <span class="material-symbols-outlined">arrow_back</span>
+                Volver al perfil
+              </button>
+              <div>
+                <h2>Editar perfil</h2>
+                <p>Actualiza tus datos personales y preferencias de acceso.</p>
+              </div>
+            </div>
+            <div class="settings-view__panel">
+              <app-profile-edit
+                [profile]="currentProfile"
+                [saving]="isSaving()"
+                [errorMessage]="updateError()"
+                (saveProfile)="handleProfileSave($event)"
+                (cancelEdit)="handleCancelEdit()"
+              ></app-profile-edit>
+            </div>
+          </div>
+        </ng-container>
+        <ng-template #summaryView>
+          <div class="summary-grid">
+            <article class="card profile-overview">
+              <div class="profile-overview__header">
+                <div class="profile-overview__avatar">
+                  <ng-container *ngIf="currentProfile.avatarUrl && !overviewAvatarError(); else overviewInitials">
+                    <img
+                      [src]="currentProfile.avatarUrl"
+                      [alt]="'Foto de ' + currentProfile.fullName"
+                      (error)="handleOverviewAvatarError()"
+                    />
+                  </ng-container>
+                  <ng-template #overviewInitials>
+                    <div class="profile-overview__initials">
+                      {{ computeInitials(currentProfile.fullName) }}
+                    </div>
+                  </ng-template>
+                </div>
+                <div>
+                  <div class="profile-overview__id">{{ currentProfile.id }}</div>
+                  <h2>{{ currentProfile.fullName }}</h2>
+                  <p>{{ currentProfile.role }}</p>
+                </div>
+              </div>
+              <dl class="profile-overview__details">
+                <div>
+                  <dt class="material-symbols-outlined">mail</dt>
+                  <dd>{{ currentProfile.email }}</dd>
+                </div>
+                <div>
+                  <dt class="material-symbols-outlined">call</dt>
+                  <dd>{{ currentProfile.phone }}</dd>
+                </div>
+                <div>
+                  <dt class="material-symbols-outlined">location_on</dt>
+                  <dd>{{ currentProfile.location }}</dd>
+                </div>
+                <div>
+                  <dt class="material-symbols-outlined">person</dt>
+                  <dd>&#64;{{ currentProfile.username }}</dd>
+                </div>
+              </dl>
+              <div class="profile-overview__actions">
+                <button type="button" class="primary-button" (click)="goToSettings()">
+                  Editar perfil
                 </button>
               </div>
-              <p class="account-card__support">
-                ¿Necesitas ayuda? Escríbenos a
-                <a [href]="'mailto:' + status.supportContact">{{ status.supportContact }}</a>.
-              </p>
-            </div>
-          </article>
+            </article>
 
-          <app-plan-details
-            [plans]="plans()"
-            [selectedPlanId]="selectedPlanId()"
-            [disabled]="isSaving()"
-            (planSelected)="handlePlanSelected($event)"
-          ></app-plan-details>
+            <article class="card account-card" *ngIf="accountStatus() as status">
+              <header class="card__header">
+                <h2>Tipo de cuenta</h2>
+                <span class="status-chip status-chip--active">
+                  <span class="material-symbols-outlined">workspace_premium</span>
+                  {{ status.statusLabel }}
+                </span>
+              </header>
+              <div class="account-card__body">
+                <p class="account-card__plan">{{ status.planName }}</p>
+                <p class="account-card__subtitle">
+                  Tu plan se renovará automáticamente el {{ status.renewalDate | date: 'dd MMMM yyyy' }}.
+                </p>
+                <div class="account-card__actions">
+                  <button
+                    type="button"
+                    class="primary-button"
+                    (click)="selectedPlanId() && handlePlanSelected(selectedPlanId()!)"
+                    [disabled]="isSaving() || !selectedPlanId()"
+                  >
+                    Mantener plan actual
+                  </button>
+                  <button type="button" class="ghost-button" [disabled]="isSaving()">
+                    Contactar soporte
+                  </button>
+                </div>
+                <p class="account-card__support">
+                  ¿Necesitas ayuda? Escríbenos a
+                  <a [href]="'mailto:' + status.supportContact">{{ status.supportContact }}</a>.
+                </p>
+              </div>
+            </article>
 
-          <app-plan-benefits [benefits]="premiumBenefits()"></app-plan-benefits>
-        </div>
+            <app-plan-details
+              class="summary-grid__plans"
+              [plans]="plans()"
+              [selectedPlanId]="selectedPlanId()"
+              [disabled]="isSaving()"
+              (planSelected)="handlePlanSelected($event)"
+            ></app-plan-details>
+
+            <app-plan-benefits class="summary-grid__benefits" [benefits]="premiumBenefits()"></app-plan-benefits>
+          </div>
+        </ng-template>
       </ng-container>
     </ng-container>
   </section>

--- a/src/app/profile/services/profile.service.ts
+++ b/src/app/profile/services/profile.service.ts
@@ -13,7 +13,7 @@ export class ProfileService {
   private readonly profileEndpoint = `${environment.apiUrl}/profiles`;
   private readonly plansEndpoint = `${environment.apiUrl}/subscriptionPlans`;
   private readonly benefitsEndpoint = `${environment.apiUrl}/premiumBenefits`;
-  private readonly profileId = 'current';
+  private readonly profileId = 'us-001';
 
   private readonly profileSubject = new BehaviorSubject<Profile | null>(null);
   private readonly plansSubject = new BehaviorSubject<SubscriptionPlan[]>([]);


### PR DESCRIPTION
## Summary
- update the mock profile record to use the new us-001 identifier and include an avatar URL
- extend profile models and services to expose the avatar and fetch the new identifier
- redesign the profile page with a summary view, avatar rendering, and a dedicated settings layout for editing

## Testing
- npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_b_68e1a44f83d883309d7e6b8d5e396911